### PR TITLE
Bump ffnvcodec

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Builds run daily at 12:00 UTC and are automatically released on success.
 ## Package List
 
 For a list of included dependencies check the scripts.d directory.
-Every file corrosponds to its respective package.
+Every file corresponds to its respective package.
 
 ## How to make a build
 

--- a/scripts.d/50-ffnvcodec.sh
+++ b/scripts.d/50-ffnvcodec.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 FFNVCODEC_REPO="https://git.videolan.org/git/ffmpeg/nv-codec-headers.git"
-FFNVCODEC_COMMIT="c928e22d81869fefb63a86405c0e1cbed8763a9e"
+FFNVCODEC_COMMIT="b6600f507de70d223101fe98f9c3c351b724e2fa"
 
 ffbuild_enabled() {
     return 0


### PR DESCRIPTION
Currently trying to make an image for building results in the following error:

```
Step 40/70 : RUN run_stage
 ---> Running in f3cc6265c5ef
+ source /stage.sh
++ FFNVCODEC_REPO=https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
++ FFNVCODEC_COMMIT=c928e22d81869fefb63a86405c0e1cbed8763a9e
+ ffbuild_dockerbuild
+ git-mini-clone https://git.videolan.org/git/ffmpeg/nv-codec-headers.git c928e22d81869fefb63a86405c0e1cbed8763a9e ffnvcodec
+ REPO=https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+ REF=c928e22d81869fefb63a86405c0e1cbed8763a9e
+ DEST=ffnvcodec
+ git init ffnvcodec
Initialized empty Git repository in /ffnvcodec/.git/
+ git -C ffnvcodec remote add origin https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+ git -C ffnvcodec fetch --depth=1 origin c928e22d81869fefb63a86405c0e1cbed8763a9e
error: Server does not allow request for unadvertised object c928e22d81869fefb63a86405c0e1cbed8763a9e
The command '/bin/sh -c run_stage' returned a non-zero code: 128
```

Looks like the remote repo is restricting access to non-head revisions for some reason. Bumping the commit id to the newest one helps.

Unfortunately, this is only a temporary solution but I'm not sure if there's a good way to futureproof this. Probably only hardcoding master would help.

Also fix a typo in `README.md` for good measure.