### PR TITLE
Update SVT-AV1 to release 0.8.7

### DIFF
--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SVTAV1_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SVTAV1_COMMIT="0a253a1cec457d50a3a441cec4d553c817bb7231"
+SVTAV1_COMMIT="3971c982311d49f9355dc8dccdcf8d21b70fa624"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1


### PR DESCRIPTION
SVT-AV1 0.8.7 gives a great speed boost of up to 35% at Preset 8 (fastest) against 0.8.6, without sacrificing quality.

Tag 0.8.7, Commit 3971c982311d49f9355dc8dccdcf8d21b70fa624

https://gitlab.com/AOMediaCodec/SVT-AV1/-/tags/v0.8.7