### PR TITLE
Ignore Readme Files In Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
     types: [build]
   schedule:
     - cron: '0 12 * * *'
+  paths-ignore:  
+    - '**.md'
 
 env:
   DOCKER_BUILDKIT: 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
 
 env:
   DOCKER_BUILDKIT: 1


### PR DESCRIPTION
This will ignore the running of the workflow file when someone pushes (commits) edits to a readme file or when someone pull requests readme ( markdown ) file.
If you merge this I'll try to pull request some readme edits contain badges.