### PR TITLE
Use flexible shebang for user scripts

### DIFF
--- a/addins/4.4.sh
+++ b/addins/4.4.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GIT_BRANCH="release/4.4"

--- a/addins/debug.sh
+++ b/addins/debug.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 FF_CONFIGURE="${FF_CONFIGURE/--disable-debug/} --optflags='-Og' --disable-stripping"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 shopt -s globstar
 cd "$(dirname "$0")"

--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 cd "$(dirname "$0")"
 source util/vars.sh

--- a/makeimage.sh
+++ b/makeimage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 cd "$(dirname "$0")"
 source util/vars.sh

--- a/util/prunetags.sh
+++ b/util/prunetags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 git fetch --tags
 TAGS=( $(git tag -l "autobuild-*" | sort -r) )

--- a/util/update_wiki.sh
+++ b/util/update_wiki.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ $# != 2 ]]; then

--- a/util/vars.sh
+++ b/util/vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# -lt 2 ]]; then
     echo "Invalid Arguments"

--- a/variants/default-install.sh
+++ b/variants/default-install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"

--- a/variants/defaults-gpl-shared.sh
+++ b/variants/defaults-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh
 FF_CONFIGURE+=" --enable-shared --disable-static"

--- a/variants/defaults-lgpl-shared.sh
+++ b/variants/defaults-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh
 FF_CONFIGURE+=" --enable-shared --disable-static"

--- a/variants/linux-install-shared.sh
+++ b/variants/linux-install-shared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"

--- a/variants/linux64-gpl-shared.sh
+++ b/variants/linux64-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/linux64-gpl.sh
+++ b/variants/linux64-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/default-install.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/linux64-lgpl-shared.sh
+++ b/variants/linux64-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/linux64-lgpl.sh
+++ b/variants/linux64-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/default-install.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/linux64-nonfree-shared.sh
+++ b/variants/linux64-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux64-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/linux64-nonfree.sh
+++ b/variants/linux64-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux64-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/win32-gpl-shared.sh
+++ b/variants/win32-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/win32-gpl.sh
+++ b/variants/win32-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/default-install.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/win32-lgpl-shared.sh
+++ b/variants/win32-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/win32-lgpl.sh
+++ b/variants/win32-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/default-install.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/win32-nonfree-shared.sh
+++ b/variants/win32-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win32-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/win32-nonfree.sh
+++ b/variants/win32-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win32-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/win64-gpl-shared.sh
+++ b/variants/win64-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/win64-gpl.sh
+++ b/variants/win64-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/default-install.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/win64-lgpl-shared.sh
+++ b/variants/win64-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/win64-lgpl.sh
+++ b/variants/win64-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/default-install.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/win64-nonfree-shared.sh
+++ b/variants/win64-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win64-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/win64-nonfree.sh
+++ b/variants/win64-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win64-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/windows-install-shared.sh
+++ b/variants/windows-install-shared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"


### PR DESCRIPTION
User environments do not necessarily have correct bash at `/bin/bash`. Shebang fixed at `#!/bin/bash` may result in error.

This code change replaces shebang in scripts that are run in host OS with `#!/usr/bin/env bash`. Scripts that are run in guest OS or in VM are untouched.