### PR TITLE
Add aribb24 for ARIB caption support

### DIFF
--- a/patches/libpng/0001-fix-build.patch
+++ b/patches/libpng/0001-fix-build.patch
@@ -1,0 +1,25 @@
+From 41dc61558ca886b4780e3f319184c9e0ae52b67c Mon Sep 17 00:00:00 2001
+From: shirt <2660574+shirt-dev@users.noreply.github.com>
+Date: Tue, 1 Feb 2022 11:37:02 -0500
+Subject: [PATCH] Update pnglibconf.dfa
+
+---
+ scripts/pnglibconf.dfa | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scripts/pnglibconf.dfa b/scripts/pnglibconf.dfa
+index b298a72f3..c45b53f0d 100644
+--- a/scripts/pnglibconf.dfa
++++ b/scripts/pnglibconf.dfa
+@@ -266,7 +266,7 @@ option POWERPC_VSX_CHECK disabled,
+ # The TEXT values are the defaults when writing compressed text (all forms)
+ 
+ # Include the zlib header so that the defaults below are known
+-@#  include <zlib.h>
++#@#  include <zlib.h>
+ 
+ # The '@' here means to substitute the value when pnglibconf.h is built
+ setting Z_DEFAULT_COMPRESSION default @Z_DEFAULT_COMPRESSION
+-- 
+2.34.1.windows.1
+

--- a/scripts.d/25-libpng.sh
+++ b/scripts.d/25-libpng.sh
@@ -20,7 +20,7 @@ ffbuild_dockerbuild() {
         git am < "$patch"
     done
 
-    autoreconf -fi
+    autoreconf -i
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"

--- a/scripts.d/25-libpng.sh
+++ b/scripts.d/25-libpng.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+LIBPNG_REPO="https://github.com/glennrp/libpng.git"
+LIBPNG_COMMIT="c17d164b4467f099b4484dfd4a279da0bc1dbd4a"
+
+ffbuild_enabled() {
+    return 0
+}
+
+ffbuild_dockerstage() {
+    to_df "RUN --mount=src=${SELF},dst=/stage.sh --mount=src=patches/libpng,dst=/patches run_stage /stage.sh"
+}
+
+ffbuild_dockerbuild() {
+    git-mini-clone "$LIBPNG_REPO" "$LIBPNG_COMMIT" libpng 
+    cd libpng
+
+    for patch in /patches/*.patch; do
+        echo "Applying $patch"
+        git am < "$patch"
+    done
+
+    autoreconf -fi
+
+    local myconf=(
+        --prefix="$FFBUILD_PREFIX"
+        --disable-shared
+        --enable-static
+        --with-pic
+    )
+
+    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+        myconf+=(
+            --host="$FFBUILD_TOOLCHAIN"
+        )
+    else
+        echo "Unknown target"
+        return -1
+    fi
+
+    ./configure "${myconf[@]}"
+    make -j$(nproc)
+    make install
+}

--- a/scripts.d/50-libaribb24.sh
+++ b/scripts.d/50-libaribb24.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+ARIBB24_REPO="https://github.com/nkoriyama/aribb24.git"
+ARIBB24_COMMIT="5e9be272f96e00f15a2f3c5f8ba7e124862aec38"
+
+ffbuild_enabled() {
+    [[ $VARIANT == lgpl* ]] && return -1
+    return 0
+}
+
+ffbuild_dockerbuild() {
+    git-mini-clone "$ARIBB24_REPO" "$ARIBB24_COMMIT" aribb24
+    cd aribb24
+
+    autoreconf -fi
+
+    local myconf=(
+        --prefix="$FFBUILD_PREFIX"
+        --disable-shared
+        --enable-static
+        --with-pic
+    )
+
+    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+        myconf+=(
+            --host="$FFBUILD_TOOLCHAIN"
+        )
+    else
+        echo "Unknown target"
+        return -1
+    fi
+
+    ./configure "${myconf[@]}"
+    make -j$(nproc)
+    make install
+}
+
+ffbuild_configure() {
+    echo --enable-libaribb24
+}
+
+ffbuild_unconfigure() {
+    echo --disable-libaribb24
+}

--- a/scripts.d/50-libaribb24.sh
+++ b/scripts.d/50-libaribb24.sh
@@ -12,7 +12,7 @@ ffbuild_dockerbuild() {
     git-mini-clone "$ARIBB24_REPO" "$ARIBB24_COMMIT" aribb24
     cd aribb24
 
-    autoreconf -fi
+    autoreconf -i
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"


### PR DESCRIPTION
This PR adds support for libaribb24, a library used for decoding closed captioning from ISDB streams, commonly used on Japanese TV.