### PR TITLE
Fix Windows-only or Linux-only builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,7 @@ jobs:
         id: create_release
         run: |
           set -xe
+          shopt -s nullglob
           RELDATE="$(date +'%Y-%m-%d %H:%M')"
           NAME="Auto-Build $RELDATE"
           TAGNAME="autobuild-$(date +'%Y-%m-%d-%H-%M')"
@@ -179,6 +180,7 @@ jobs:
       - name: Update Latest
         run: |
           set -xe
+          shopt -s nullglob
           mkdir latest_artifacts
           ./util/repack_latest.sh latest_artifacts artifacts/*.{zip,tar.xz}
           NAME="Latest Auto-Build (${{ steps.create_release.outputs.rel_date }})"


### PR DESCRIPTION
`artifacts/*.{zip,tar.xz}` fails with `artifacts/*.tar.xz: no such file or directory` if FFmpeg for Linux was not build.