### PR TITLE
mfx: fix plugins loading issue

### DIFF
--- a/patches/mfx/0000-fix-the-mfx-plugins-loading-issues.patch
+++ b/patches/mfx/0000-fix-the-mfx-plugins-loading-issues.patch
@@ -1,0 +1,39 @@
+From 9dbf2b7c80eb4bbe85022602e7b193420d9c38f9 Mon Sep 17 00:00:00 2001
+From: nyanmisaka <nst799610810@gmail.com>
+Date: Fri, 28 Oct 2022 00:01:11 +0800
+Subject: [PATCH] Fix the MFX plugins loading issues
+
+Signed-off-by: nyanmisaka <nst799610810@gmail.com>
+---
+ src/mfxloader.cpp | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/src/mfxloader.cpp b/src/mfxloader.cpp
+index 2f676f5..776e958 100644
+--- a/src/mfxloader.cpp
++++ b/src/mfxloader.cpp
+@@ -452,7 +452,21 @@ mfxStatus MFXVideoUSER_Load(mfxSession session, const mfxPluginUID *uid, mfxU32
+       if (MFX::g_GlobalCtx.m_plugins.empty()) {
+         // Parsing plugin configuration file and loading information of
+         // _all_ plugins registered on the system.
++#if defined(__linux__)
++        // Hardcode common plugins paths for most linux distros in case of
++        // the legacy mfxdispatcher is configured to static build.
++        const char *plugins_paths[3] = { "/usr/share/mfx/plugins.cfg",
++                                         "/usr/local/share/mfx/plugins.cfg",
++                                         "/opt/intel/mediasdk/plugins/plugins.cfg" };
++        for (int i = 0; i < sizeof(plugins_paths) / sizeof(plugins_paths[0]); i++) {
++          if (fopen(plugins_paths[i], "r") != NULL) {
++            parse(plugins_paths[i], MFX::g_GlobalCtx.m_plugins);
++            break;
++          }
++        }
++#else
+         parse(MFX_PLUGINS_CONF_DIR "/plugins.cfg", MFX::g_GlobalCtx.m_plugins);
++#endif
+       }
+ 
+       // search for plugin description
+-- 
+2.25.1
+

--- a/scripts.d/50-mfx.sh
+++ b/scripts.d/50-mfx.sh
@@ -9,9 +9,18 @@ ffbuild_enabled() {
     return 0
 }
 
+ffbuild_dockerstage() {
+    to_df "RUN --mount=src=${SELF},dst=/stage.sh --mount=src=patches/mfx,dst=/patches run_stage /stage.sh"
+}
+
 ffbuild_dockerbuild() {
     git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" mfx
     cd mfx
+
+    for patch in /patches/*.patch; do
+        echo "Applying $patch"
+        git am < "$patch"
+    done
 
     autoreconf -i
 


### PR DESCRIPTION
In the static build of MFX dispatcher on Linux, plugins are not shipped with dispatcher. Therefore, the ffmpeg linked to this dispatcher cannot find the location of plugins according to `plugins.cfg`, and causes HEVC encoding to fail.

So we should hardcode the default paths of some common `plugins.cfg` so that dispatcher can find plugins correctly.

plugins.cfg: [plugins.cfg.txt](https://github.com/BtbN/FFmpeg-Builds/files/9881359/plugins.cfg.txt)

Also, oneVPL no longer needs plugins.

Signed-off-by: nyanmisaka <nst799610810@gmail.com>