### PR TITLE
Update rubberband build options

### DIFF
--- a/scripts.d/50-rubberband.sh
+++ b/scripts.d/50-rubberband.sh
@@ -17,6 +17,8 @@ ffbuild_dockerbuild() {
     local myconf=(
         --prefix="$FFBUILD_PREFIX"
         -Ddefault_library=static
+        -Dfft=fftw
+        -Dresampler=libsamplerate
     )
 
     if [[ $TARGET == win* || $TARGET == linux* ]]; then
@@ -31,9 +33,6 @@ ffbuild_dockerbuild() {
     meson "${myconf[@]}" ..
     ninja -j$(nproc)
     ninja install
-
-    # Fix static linking
-    echo "Requires.private: fftw3 samplerate" >> "$FFBUILD_PREFIX"/lib/pkgconfig/rubberband.pc
 }
 
 ffbuild_configure() {


### PR DESCRIPTION
Found this on build log
https://github.com/BtbN/FFmpeg-Builds/actions/runs/3364861363/jobs/5579712762

```
Configuration
     FFT                      : Built-in
     Resampler                : Built-in
     Build type               : Release
     Architecture             : x86_64
```

After added options:

```
Configuration
     FFT                      : FFTW
     Resampler                : libsamplerate
     Build type               : Release
     Architecture             : x86_64
```

its pc file before:
cat /opt/ffbuild/lib/pkgconfig/rubberband.pc
```
prefix=/opt/ffbuild
includedir=${prefix}/include
libdir=${prefix}/lib

Name: rubberband
Description: Audio time-stretching and pitch-shifting library
URL: https://breakfastquay.com/rubberband/
Version: 3.1.0
Libs: -L${libdir} -lrubberband
Cflags: -I${includedir} -I${includedir}
Requires.private: fftw3 samplerate
```

after:

```
prefix=/opt/ffbuild
includedir=${prefix}/include
libdir=${prefix}/lib

Name: rubberband
Description: Audio time-stretching and pitch-shifting library
URL: https://breakfastquay.com/rubberband/
Version: 3.1.0
Requires: fftw3 >=  3.0.0, samplerate >=  0.1.8
Libs: -L${libdir} -lrubberband
Cflags: -I${includedir} -I${includedir}

```