### PR TITLE
Omit the ``--filter=blob:none`` option passed to git clone

### DIFF
--- a/scripts.d/20-libiconv.sh
+++ b/scripts.d/20-libiconv.sh
@@ -8,7 +8,7 @@ ffbuild_enabled() {
 }
 
 ffbuild_dockerbuild() {
-    git clone --filter=blob:none "$SCRIPT_REPO" iconv
+    git clone "$SCRIPT_REPO" iconv
     cd iconv
     git checkout "$SCRIPT_COMMIT"
 


### PR DESCRIPTION
This should prevent the "filtering not recognized by server, ignoring" warning on git clone.