### PR TITLE
Fix AVS3 10 bit decode on Windows

### DIFF
--- a/scripts.d/50-uavs3d.sh
+++ b/scripts.d/50-uavs3d.sh
@@ -13,6 +13,8 @@ ffbuild_dockerbuild() {
     cd uavs3d
     git checkout "$SCRIPT_COMMIT"
 
+    sed -i '50c \ ' source/decore/com_def.h
+   
     mkdir build/linux
     cd build/linux
 


### PR DESCRIPTION
Now, Actions' builds can not decode AVS3 10 bit. A bug in uavs3d causes `COMPILE_10BIT` to always be `0`.

https://github.com/uavs3/uavs3d/blob/b8f8e215297ff98ee78162fdc3d9c52d16b113d5/source/decore/com_def.h#L39-L58

I changed script to remove `#define COMPILE_10BIT 0`.