### PR TITLE
Fix the path to fontconfig configuration file

### DIFF
--- a/scripts.d/35-fontconfig.sh
+++ b/scripts.d/35-fontconfig.sh
@@ -22,7 +22,13 @@ ffbuild_dockerbuild() {
         --enable-static
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == linux* ]]; then
+        myconf+=(
+            --sysconfdir=/etc
+            --localstatedir=/var
+            --host="$FFBUILD_TOOLCHAIN"
+        )
+    elif [[ $TARGET == win* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )


### PR DESCRIPTION
Instead of using the install prefix + /etc or /var. This fixes a subtitle rendering issue on Linux.

![image](https://user-images.githubusercontent.com/14953024/224525804-73574623-9874-4434-b72d-13bd1f073953.png)

```
[Parsed_subtitles_2 @ 0x559d390ef480] libass API version: 0x1701000
[Parsed_subtitles_2 @ 0x559d390ef480] libass source: commit: 218dacece7d24b45e4637ced4dc56564de29919d
[Parsed_subtitles_2 @ 0x559d390ef480] Shaper: FriBidi 1.0.12 (SIMPLE) HarfBuzz-ng 7.1.0 (COMPLEX)
[Parsed_subtitles_2 @ 0x559d390ef480] Loading font file '/var/cache/jellyfin/attachments/5bf07c52b32fc0306e2d4d65c9f7fca7/Roboto-Medium.ttf'
Fontconfig error: Cannot load default config file: No such file: (null)
[Parsed_subtitles_2 @ 0x559d390ef480] No usable fontconfig configuration file found, using fallback.
Fontconfig error: Cannot load default config file: No such file: (null)
[Parsed_subtitles_2 @ 0x559d390ef480] Using font provider fontconfig
[Parsed_subtitles_2 @ 0x559d390ef480] fontselect: (Roboto Medium, 400, 0) -> Roboto-Medium, 0, Roboto-Medium
```

```
access("/opt/ffbuild/etc/fonts/fonts.conf", R_OK) = -1 ENOENT (No such file or directory)
write(2, "Fontconfig error: ", 18Fontconfig error: )      = 18
write(2, "Cannot load default config file:"..., 53Cannot load default config file: No such file: (null)) = 53
write(2, "\n", 1
)                       = 1
write(2, "[Parsed_subtitles_0 @ 0x55a3fe8a"..., 38[Parsed_subtitles_0 @ 0x55a3fe8a2680] ) = 38
write(2, "No usable fontconfig configurati"..., 62No usable fontconfig configuration file found, using fallback.) = 62
openat(AT_FDCWD, "/opt/ffbuild/var/cache/fontconfig//4c599c202bc5c08e2d34565a40eac3b2-le64.cache-9", O_RDONLY|O_CLOEXEC) = -1 ENOENT (No such file or directory)
```