### PR TITLE
Build cargo-c with --locked to work around rust-lang/cargo#13002

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -22,7 +22,7 @@ RUN \
 
 ENV CARGO_HOME="/opt/cargo" RUSTUP_HOME="/opt/rustup" PATH="/opt/cargo/bin:${PATH}"
 RUN curl https://sh.rustup.rs -sSf | bash -s -- -y --no-modify-path && \
-    cargo install cargo-c && rm -rf "${CARGO_HOME}"/registry "${CARGO_HOME}"/git
+    cargo install cargo-c --locked && rm -rf "${CARGO_HOME}"/registry "${CARGO_HOME}"/git
 
 RUN --mount=src=.,dst=/input \
     for s in /input/*.sh; do cp $s /usr/bin/$(echo $s | sed -e 's|.*/||' -e 's/\.sh$//'); done


### PR DESCRIPTION
Based on: https://github.com/AOMediaCodec/libavif/pull/1785

Addresses: https://github.com/BtbN/FFmpeg-Builds/issues/320

As noted in the referenced fix, "using --locked might be advisable anyway to ensure reproducible builds.". Unsure of the veracity of this claim, but using `--locked` worked to bypass the issue for me locally.