### PR TITLE
Update SVT-AV1 to v1.8.0

### DIFF
--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="a49c786a81383d2dee7c8cdc8b5d46e5df3a7845"
+SCRIPT_COMMIT="5fbddb53b3dc1a32f35ade563e2f6d32dc500417"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1


### PR DESCRIPTION
Updates the SVT-AV1 repo commit to 5fbddb53b3dc1a32f35ade563e2f6d32dc500417.

Old version is v1.7.0-17-ga49c786a.

Chanelog below

---

Encoder

- Improve the tradeoffs for the random access mode across presets:
- Speedup CRF presets M6 to M0 by 17-53% while maintaining similar quality levels
- Re-adjust CRF presets M7 to M13 for better quality with BD-rate gains ranging from 1-4%
- Improve the quality and speed of the 1-pass VBR mode
- More details on the per preset improvements can be found in MR [!2143](https://github.com/AOMediaCodec/SVT-AV1/-/merge_requests/2143)
- Add API allowing to update bitrate / CRF and Key_frame placement during the encoding session for CBR lowdelay mode and CRF Random Access mode
- ARM Neon SIMD optimizations for most critical kernels allowing for a 4.5-8x fps speedup vs the c implementation

Cleanup and bug fixes and documentation

- Various cleanups and functional bug fixes
- Update the documentation for preset options and individual features