### PR TITLE
Ability to build binaries on (not for) macOS (2nd attempt)

### DIFF
--- a/addins/4.4.sh
+++ b/addins/4.4.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GIT_BRANCH="release/4.4"

--- a/addins/5.0.sh
+++ b/addins/5.0.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GIT_BRANCH="release/5.0"

--- a/addins/5.1.sh
+++ b/addins/5.1.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GIT_BRANCH="release/5.1"

--- a/addins/6.0.sh
+++ b/addins/6.0.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GIT_BRANCH="release/6.0"

--- a/addins/6.1.sh
+++ b/addins/6.1.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 GIT_BRANCH="release/6.1"

--- a/addins/debug.sh
+++ b/addins/debug.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 FF_CONFIGURE="${FF_CONFIGURE/--disable-debug/} --optflags='-Og' --disable-stripping"

--- a/addins/lto.sh
+++ b/addins/lto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 FF_CONFIGURE="$FF_CONFIGURE --enable-lto"
 
 ffbuild_dockeraddin() {

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 set -xe
 shopt -s globstar
 cd "$(dirname "$0")"
+export SYSTEM_NAME="$(uname -s)"
 source util/vars.sh
 
 get_output() {
@@ -43,7 +44,13 @@ FF_LIBS="$(xargs <<< "$FF_LIBS")"
 TESTFILE="uidtestfile"
 rm -f "$TESTFILE"
 docker run --rm -v "$PWD:/uidtestdir" "$IMAGE" touch "/uidtestdir/$TESTFILE"
-DOCKERUID="$(stat -c "%u" "$TESTFILE")"
+
+if [[ "$SYSTEM_NAME" = "Darwin" ]]; then
+    DOCKERUID="$(stat -f "%u" "$TESTFILE")"
+else
+    DOCKERUID="$(stat -c "%u" "$TESTFILE")"
+fi
+
 rm -f "$TESTFILE"
 [[ "$DOCKERUID" != "$(id -u)" ]] && UIDARGS=( -u "$(id -u):$(id -g)" ) || UIDARGS=()
 unset TESTFILE

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 shopt -s globstar
 cd "$(dirname "$0")"

--- a/download.sh
+++ b/download.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 cd "$(dirname "$0")"
 source util/vars.sh dl only

--- a/download.sh
+++ b/download.sh
@@ -6,7 +6,13 @@ source util/vars.sh dl only
 TESTFILE="uidtestfile"
 rm -f "$TESTFILE"
 docker run --rm -v "$PWD:/uidtestdir" "${REGISTRY}/${REPO}/base:latest" touch "/uidtestdir/$TESTFILE"
-DOCKERUID="$(stat -c "%u" "$TESTFILE")"
+
+if [[ "$SYSTEM_NAME" = "Darwin" ]]; then
+    DOCKERUID="$(stat -f "%u" "$TESTFILE")"
+else
+    DOCKERUID="$(stat -c "%u" "$TESTFILE")"
+fi
+
 rm -f "$TESTFILE"
 [[ "$DOCKERUID" != "$(id -u)" ]] && UIDARGS=( -u "$(id -u):$(id -g)" ) || UIDARGS=()
 unset TESTFILE

--- a/generate.sh
+++ b/generate.sh
@@ -61,7 +61,7 @@ for addin in "${ADDINS[@]}"; do
 done
 
 PREVLAYER="base"
-for ID in $(ls -1d scripts.d/??-* | sed -s 's|^.*/\(..\).*|\1|' | sort -u); do
+for ID in $(ls -1d scripts.d/??-* | sed 's|^.*/\(..\).*|\1|' | sort -u); do
     LAYER="layer-$ID"
 
     for STAGE in scripts.d/$ID-*; do

--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cd "$(dirname "$0")"
 source util/vars.sh

--- a/images/base-linux64/gen-implib.sh
+++ b/images/base-linux64/gen-implib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [[ $# != 2 ]]; then
     echo "Invalid arguments"

--- a/images/base-linuxarm64/gen-implib.sh
+++ b/images/base-linuxarm64/gen-implib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [[ $# != 2 ]]; then
     echo "Invalid arguments"

--- a/images/base/check-wget.sh
+++ b/images/base/check-wget.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 FNAME="$1"
 URL="$2"

--- a/images/base/git-mini-clone.sh
+++ b/images/base/git-mini-clone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 REPO="$1"
 REF="$2"

--- a/images/base/retry-tool.sh
+++ b/images/base/retry-tool.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe -o pipefail
 
 RETRY_COUNTER=0

--- a/makeimage.sh
+++ b/makeimage.sh
@@ -3,7 +3,13 @@ set -xe
 cd "$(dirname "$0")"
 source util/vars.sh
 
-TMPCFG="$(mktemp --suffix=.toml)"
+export SYSTEM_NAME="$(uname -s)"
+
+if [[ "$SYSTEM_NAME" = "Darwin" ]]; then
+  TMPCFG="$(mktemp -t temp.XXXXXX.toml)"
+else
+  TMPCFG="$(mktemp --suffix=.toml)"
+fi
 cat <<EOF >"$TMPCFG"
 [worker.oci]
   max-parallelism = 4

--- a/makeimage.sh
+++ b/makeimage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 cd "$(dirname "$0")"
 source util/vars.sh

--- a/scripts.d/10-mingw-std-threads.sh
+++ b/scripts.d/10-mingw-std-threads.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/meganz/mingw-std-threads.git"
 SCRIPT_COMMIT="c931bac289dd431f1dd30fc4a5d1a7be36668073"

--- a/scripts.d/10-mingw.sh
+++ b/scripts.d/10-mingw.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
 SCRIPT_COMMIT="f2653dd9150006ded8026631bb7b85695edf6127"

--- a/scripts.d/10-xorg-macros.sh
+++ b/scripts.d/10-xorg-macros.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/util/macros.git"
 SCRIPT_COMMIT="cb147377e9341af05232f95814022abdecf14024"

--- a/scripts.d/20-libiconv.sh
+++ b/scripts.d/20-libiconv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://git.savannah.gnu.org/git/libiconv.git"
 SCRIPT_COMMIT="317dfadc6c68b3465205873b140200e5b0d0256f"

--- a/scripts.d/20-libxml2.sh
+++ b/scripts.d/20-libxml2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
 SCRIPT_COMMIT="355fbe3ab7277cd5f21a41fcb81be69ad438c5eb"

--- a/scripts.d/20-zlib.sh
+++ b/scripts.d/20-zlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/madler/zlib.git"
 SCRIPT_COMMIT="643e17b7498d12ab8d15565662880579692f769d"

--- a/scripts.d/25-fftw3.sh
+++ b/scripts.d/25-fftw3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/FFTW/fftw3.git"
 SCRIPT_COMMIT="d0ce926f1523d95daed48cd7c69572e068dbbfb3"

--- a/scripts.d/25-freetype.sh
+++ b/scripts.d/25-freetype.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
 SCRIPT_COMMIT="ca76683b781db5d06ef1a0e2cb62a767e7dbe626"

--- a/scripts.d/25-fribidi.sh
+++ b/scripts.d/25-fribidi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/fribidi/fribidi.git"
 SCRIPT_COMMIT="5b9a242cbbb0cf27d20da9941667abfc63808c19"

--- a/scripts.d/25-gmp.sh
+++ b/scripts.d/25-gmp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/BtbN/gmplib.git"
 SCRIPT_COMMIT="9dff3be5f5bd1f417a81a482bb59f4b25c33cc8a"

--- a/scripts.d/25-libogg.sh
+++ b/scripts.d/25-libogg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xiph/ogg.git"
 SCRIPT_COMMIT="db5c7a49ce7ebda47b15b78471e78fb7f2483e22"

--- a/scripts.d/25-openssl.sh
+++ b/scripts.d/25-openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/openssl/openssl.git"
 SCRIPT_COMMIT="openssl-3.0.12"

--- a/scripts.d/25-xz.sh
+++ b/scripts.d/25-xz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xz-mirror/xz.git"
 SCRIPT_COMMIT="74c3449d8b816a724b12ebce7417e00fb597309a"

--- a/scripts.d/35-fontconfig.sh
+++ b/scripts.d/35-fontconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
 SCRIPT_COMMIT="91a57074652872353ded6aa74fe54213056daf40"

--- a/scripts.d/45-harfbuzz.sh
+++ b/scripts.d/45-harfbuzz.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
 SCRIPT_COMMIT="f3efa6f6e54740214739ba8b00e777111e781882"

--- a/scripts.d/45-libsamplerate.sh
+++ b/scripts.d/45-libsamplerate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/libsndfile/libsamplerate.git"
 SCRIPT_COMMIT="20819b6d31907b402d33c30e4a0295ce439c06e6"

--- a/scripts.d/45-libudfread.sh
+++ b/scripts.d/45-libudfread.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libudfread.git"
 SCRIPT_COMMIT="b3e6936a23f8af30a0be63d88f4695bdc0ea26e1"

--- a/scripts.d/45-libvorbis.sh
+++ b/scripts.d/45-libvorbis.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xiph/vorbis.git"
 SCRIPT_COMMIT="84c023699cdf023a32fa4ded32019f194afcdad0"

--- a/scripts.d/45-opencl.sh
+++ b/scripts.d/45-opencl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/OpenCL-Headers.git"
 SCRIPT_COMMIT="2368105c0531069fe927989505de7d125ec58c55"

--- a/scripts.d/45-pulseaudio.sh
+++ b/scripts.d/45-pulseaudio.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/pulseaudio/pulseaudio.git"
 SCRIPT_COMMIT="81a6cc4967d1f19cef800932b10ade7f896ee2ea"

--- a/scripts.d/45-vmaf.sh
+++ b/scripts.d/45-vmaf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/Netflix/vmaf.git"
 SCRIPT_COMMIT="cf67786bd63070bd06e76cc73caa4baca128ce1f"

--- a/scripts.d/45-x11/10-xcbproto.sh
+++ b/scripts.d/45-x11/10-xcbproto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
 SCRIPT_COMMIT="1388374c7149114888a6a5cd6e9bf6ad4b42adf8"

--- a/scripts.d/45-x11/10-xproto.sh
+++ b/scripts.d/45-x11/10-xproto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
 SCRIPT_COMMIT="1c8128d72df22843a2022576850bc5ab5e3a46ea"

--- a/scripts.d/45-x11/10-xtrans.sh
+++ b/scripts.d/45-x11/10-xtrans.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxtrans.git"
 SCRIPT_COMMIT="806f04c6e4529358f160e53135baf105e4ecf3b8"

--- a/scripts.d/45-x11/20-libxau.sh
+++ b/scripts.d/45-x11/20-libxau.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxau.git"
 SCRIPT_COMMIT="f4fc44202b554e68093828b556f8c7fd9644ddb0"

--- a/scripts.d/45-x11/30-libxcb.sh
+++ b/scripts.d/45-x11/30-libxcb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
 SCRIPT_COMMIT="3c946010c8521497b0fba2c8bc9bde184622345a"

--- a/scripts.d/45-x11/40-libx11.sh
+++ b/scripts.d/45-x11/40-libx11.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
 SCRIPT_COMMIT="c745719e23af44a4b40ab4508447637b35d91a1e"

--- a/scripts.d/45-x11/50-libxext.sh
+++ b/scripts.d/45-x11/50-libxext.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxext.git"
 SCRIPT_COMMIT="6cb21433d745abea3a161a6fc8e141f7e08b2c27"

--- a/scripts.d/45-x11/50-libxfixes.sh
+++ b/scripts.d/45-x11/50-libxfixes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxfixes.git"
 SCRIPT_COMMIT="c1cab28e27dd1c5a81394965248b57e490ccf2ca"

--- a/scripts.d/45-x11/50-libxi.sh
+++ b/scripts.d/45-x11/50-libxi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxi.git"
 SCRIPT_COMMIT="a340bc0424a73d9fc4badbb7aee5284877635ca9"

--- a/scripts.d/45-x11/50-libxinerama.sh
+++ b/scripts.d/45-x11/50-libxinerama.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxinerama.git"
 SCRIPT_COMMIT="51c28095951676a5896437c4c3aa40fb1972bad2"

--- a/scripts.d/45-x11/50-libxrender.sh
+++ b/scripts.d/45-x11/50-libxrender.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrender.git"
 SCRIPT_COMMIT="01e754610df2195536c5b31c1e8df756480599d1"

--- a/scripts.d/45-x11/50-libxscrnsaver.sh
+++ b/scripts.d/45-x11/50-libxscrnsaver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver.git"
 SCRIPT_COMMIT="9b4e000c6c4ae213a3e52345751d885543f17929"

--- a/scripts.d/45-x11/50-libxxf86vm.sh
+++ b/scripts.d/45-x11/50-libxxf86vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxxf86vm.git"
 SCRIPT_COMMIT="cfda59347e3a04415340a99f925a9cd85c0531b2"

--- a/scripts.d/45-x11/60-libglvnd.sh
+++ b/scripts.d/45-x11/60-libglvnd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/glvnd/libglvnd.git"
 SCRIPT_COMMIT="908086d22dc307d17d0eb35c522c35fd190718cc"

--- a/scripts.d/45-x11/60-libxcursor.sh
+++ b/scripts.d/45-x11/60-libxcursor.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcursor.git"
 SCRIPT_COMMIT="5e0f8347cebef2b3a9f5d75ca254aabaa0bca259"

--- a/scripts.d/45-x11/60-libxrandr.sh
+++ b/scripts.d/45-x11/60-libxrandr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrandr.git"
 SCRIPT_COMMIT="512bf0b15b5597c721ff8c61083616ca9040fa72"

--- a/scripts.d/45-x11/60-libxv.sh
+++ b/scripts.d/45-x11/60-libxv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxv.git"
 SCRIPT_COMMIT="b022c9cf7004fe6f794c4c00dd519a2e4c74eca0"

--- a/scripts.d/45-x11/99-finalize.sh
+++ b/scripts.d/45-x11/99-finalize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_SKIP="1"
 

--- a/scripts.d/50-amf.sh
+++ b/scripts.d/50-amf.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git"
 SCRIPT_COMMIT="c48e50ad6c8723c006b2c145d8fa49ecc0651022"

--- a/scripts.d/50-aom.sh
+++ b/scripts.d/50-aom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://aomedia.googlesource.com/aom"
 SCRIPT_COMMIT="7a2afe7f16eef73d1d79954c2704c8d7ab4772b9"

--- a/scripts.d/50-aribb24/25-libpng.sh
+++ b/scripts.d/50-aribb24/25-libpng.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/glennrp/libpng.git"
 SCRIPT_COMMIT="2fff013a6935967960a5ae626fc21432807933dd"

--- a/scripts.d/50-aribb24/50-libaribb24.sh
+++ b/scripts.d/50-aribb24/50-libaribb24.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/nkoriyama/aribb24.git"
 SCRIPT_COMMIT="5e9be272f96e00f15a2f3c5f8ba7e124862aec38"

--- a/scripts.d/50-avisynth.sh
+++ b/scripts.d/50-avisynth.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/AviSynth/AviSynthPlus.git"
 SCRIPT_COMMIT="eb3c433031b180e97632ff32c199ccf980416bfc"

--- a/scripts.d/50-chromaprint.sh
+++ b/scripts.d/50-chromaprint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/acoustid/chromaprint.git"
 SCRIPT_COMMIT="aa67c95b9e486884a6d3ee8b0c91207d8c2b0551"

--- a/scripts.d/50-dav1d.sh
+++ b/scripts.d/50-dav1d.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
 SCRIPT_COMMIT="746ab8b4f3021d7263c64d6b5d6f1e2c281c7acc"

--- a/scripts.d/50-davs2.sh
+++ b/scripts.d/50-davs2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/pkuvcl/davs2.git"
 SCRIPT_COMMIT="b41cf117452e2d73d827f02d3e30aa20f1c721ac"

--- a/scripts.d/50-fdk-aac.sh
+++ b/scripts.d/50-fdk-aac.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/mstorsjo/fdk-aac.git"
 SCRIPT_COMMIT="c16d5d72c99a77c8bcb788a922323b0b59035803"

--- a/scripts.d/50-ffnvcodec.sh
+++ b/scripts.d/50-ffnvcodec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/FFmpeg/nv-codec-headers.git"
 SCRIPT_COMMIT="22441b505d9d9afc1e3002290820909846c24bdc"

--- a/scripts.d/50-frei0r.sh
+++ b/scripts.d/50-frei0r.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/dyne/frei0r.git"
 SCRIPT_COMMIT="a303b82f34feb39aa400bd1b67fd8158a179368e"

--- a/scripts.d/50-gme.sh
+++ b/scripts.d/50-gme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/libgme/game-music-emu.git"
 SCRIPT_COMMIT="6880d46552919f95604c87e5df14c13216927418"

--- a/scripts.d/50-kvazaar.sh
+++ b/scripts.d/50-kvazaar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/ultravideo/kvazaar.git"
 SCRIPT_COMMIT="f4294e000b72f483b32ab5cd4a4f5d5541466811"

--- a/scripts.d/50-libaribcaption.sh
+++ b/scripts.d/50-libaribcaption.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xqq/libaribcaption.git"
 SCRIPT_COMMIT="41a014d245adf66f425a8317a031477dd1f80c67"

--- a/scripts.d/50-libass.sh
+++ b/scripts.d/50-libass.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
 SCRIPT_COMMIT="c047dd2ea16f73abb4f448e6db3637158c1226d0"

--- a/scripts.d/50-libbluray.sh
+++ b/scripts.d/50-libbluray.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libbluray.git"
 SCRIPT_COMMIT="bb5bc108ec695889855f06df338958004ff289ef"

--- a/scripts.d/50-libjxl/45-brotli.sh
+++ b/scripts.d/50-libjxl/45-brotli.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/google/brotli.git"
 SCRIPT_COMMIT="fef82ea10435abb1500b615b1b2c6175d429ec6c"

--- a/scripts.d/50-libjxl/45-lcms2.sh
+++ b/scripts.d/50-libjxl/45-lcms2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/mm2/Little-CMS.git"
 SCRIPT_COMMIT="f1060e7989a68f62dd3876aa7d755d974ffd9a3a"

--- a/scripts.d/50-libjxl/50-libjxl.sh
+++ b/scripts.d/50-libjxl/50-libjxl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/libjxl/libjxl.git"
 SCRIPT_COMMIT="dff3f4609559512b9c1caa8c4036267ac9e0078d"

--- a/scripts.d/50-libmp3lame.sh
+++ b/scripts.d/50-libmp3lame.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://svn.code.sf.net/p/lame/svn/trunk/lame"
 SCRIPT_REV="6531"

--- a/scripts.d/50-libopus.sh
+++ b/scripts.d/50-libopus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
 SCRIPT_COMMIT="c85499757c148fede8604cffa12454206b6138ba"

--- a/scripts.d/50-librist/40-mbedtls.sh
+++ b/scripts.d/50-librist/40-mbedtls.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/ARMmbed/mbedtls.git"
 SCRIPT_COMMIT="v3.5.1"

--- a/scripts.d/50-librist/50-librist.sh
+++ b/scripts.d/50-librist/50-librist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://code.videolan.org/rist/librist.git"
 SCRIPT_COMMIT="1e805500dc14a507598cebdd49557c32e514899f"

--- a/scripts.d/50-libssh.sh
+++ b/scripts.d/50-libssh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://git.libssh.org/projects/libssh.git"
 SCRIPT_COMMIT="b3de3a33352a78214a534005e3e4f0576dcc9e17"

--- a/scripts.d/50-libtheora.sh
+++ b/scripts.d/50-libtheora.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xiph/theora.git"
 SCRIPT_COMMIT="7180717276af1ebc7da15c83162d6c5d6203aabf"

--- a/scripts.d/50-libvpx.sh
+++ b/scripts.d/50-libvpx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
 SCRIPT_COMMIT="41ced868a69625372c95ff0b2bd5f90987516c3b"

--- a/scripts.d/50-libwebp.sh
+++ b/scripts.d/50-libwebp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
 SCRIPT_COMMIT="d7a0506dcc9b7cf75742e16fd2707835d7ce003d"

--- a/scripts.d/50-lilv/96-lv2.sh
+++ b/scripts.d/50-lilv/96-lv2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/lv2/lv2.git"
 SCRIPT_COMMIT="e9d94328743d630e27a9d322015437fd9080695d"

--- a/scripts.d/50-lilv/96-serd.sh
+++ b/scripts.d/50-lilv/96-serd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/drobilla/serd.git"
 SCRIPT_COMMIT="14196632191339b69d9db3a242a1b8be3f960669"

--- a/scripts.d/50-lilv/96-zix.sh
+++ b/scripts.d/50-lilv/96-zix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/drobilla/zix.git"
 SCRIPT_COMMIT="08954c900820320064d2e33445858e1ef5024a0b"

--- a/scripts.d/50-lilv/97-sord.sh
+++ b/scripts.d/50-lilv/97-sord.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/drobilla/sord.git"
 SCRIPT_COMMIT="c7f822f14aae0367e184c847379496bc28adf63d"

--- a/scripts.d/50-lilv/98-sratom.sh
+++ b/scripts.d/50-lilv/98-sratom.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/lv2/sratom.git"
 SCRIPT_COMMIT="19a670806390d1980f3471710ba3a5af3d0bd64b"

--- a/scripts.d/50-lilv/99-lilv.sh
+++ b/scripts.d/50-lilv/99-lilv.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/lv2/lilv.git"
 SCRIPT_COMMIT="8ebaf1387735173e72ab79eeda2de328cd279e12"

--- a/scripts.d/50-onevpl.sh
+++ b/scripts.d/50-onevpl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/oneapi-src/oneVPL.git"
 SCRIPT_COMMIT="2274efcd3672b43297ef774f332e1fed6781381c"

--- a/scripts.d/50-openal.sh
+++ b/scripts.d/50-openal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/kcat/openal-soft.git"
 SCRIPT_COMMIT="59c466077fd6f16af64afcc6260bb61aa4e632dc"

--- a/scripts.d/50-opencore-amr.sh
+++ b/scripts.d/50-opencore-amr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/opencore-amr/code"
 SCRIPT_COMMIT="7dba8c32238418ce0b316a852b2224df586ca896"

--- a/scripts.d/50-openh264.sh
+++ b/scripts.d/50-openh264.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/cisco/openh264.git"
 SCRIPT_COMMIT="cfbd5896606b91638c8871ee91776dee31625bd5"

--- a/scripts.d/50-openjpeg.sh
+++ b/scripts.d/50-openjpeg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/uclouvain/openjpeg.git"
 SCRIPT_COMMIT="41c25e3827c68a39b9e20c1625a0b96e49955445"

--- a/scripts.d/50-openmpt.sh
+++ b/scripts.d/50-openmpt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
 SCRIPT_REV="19989"

--- a/scripts.d/50-rav1e.sh
+++ b/scripts.d/50-rav1e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/xiph/rav1e.git"
 SCRIPT_COMMIT="b9f4275e0da18fe81c314831bfcb39867b47df14"

--- a/scripts.d/50-rubberband.sh
+++ b/scripts.d/50-rubberband.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/breakfastquay/rubberband.git"
 SCRIPT_COMMIT="9ea386261b502d321bb4ded22b27ece4e5d37c68"

--- a/scripts.d/50-schannel.sh
+++ b/scripts.d/50-schannel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_SKIP="1"
 

--- a/scripts.d/50-sdl.sh
+++ b/scripts.d/50-sdl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/libsdl-org/SDL.git"
 SCRIPT_COMMIT="5773c347d58d07a45b33ac4ecc93fd3e6a86d483"

--- a/scripts.d/50-soxr.sh
+++ b/scripts.d/50-soxr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/soxr/code"
 SCRIPT_COMMIT="945b592b70470e29f917f4de89b4281fbbd540c0"

--- a/scripts.d/50-srt.sh
+++ b/scripts.d/50-srt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
 SCRIPT_COMMIT="5f57dde37fcaaa79f972162ccc4bba79e6b95996"

--- a/scripts.d/50-svtav1.sh
+++ b/scripts.d/50-svtav1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
 SCRIPT_COMMIT="59645eea34e2815b627b8293aa3af254eddd0d69"

--- a/scripts.d/50-twolame.sh
+++ b/scripts.d/50-twolame.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/njh/twolame.git"
 SCRIPT_COMMIT="90b694b6125dbe23a346bd5607a7fb63ad2785dc"

--- a/scripts.d/50-uavs3d.sh
+++ b/scripts.d/50-uavs3d.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/uavs3/uavs3d.git"
 SCRIPT_COMMIT="1fd04917cff50fac72ae23e45f82ca6fd9130bd8"

--- a/scripts.d/50-vaapi/30-libpciaccess.sh
+++ b/scripts.d/50-vaapi/30-libpciaccess.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libpciaccess.git"
 SCRIPT_COMMIT="c74d0a4b630f115e797cbb159ac13e0dc78f31f5"

--- a/scripts.d/50-vaapi/40-libdrm.sh
+++ b/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
 SCRIPT_COMMIT="02a41cf302a69f0cd94aae96ec01d98b9398076e"

--- a/scripts.d/50-vaapi/50-libva.sh
+++ b/scripts.d/50-vaapi/50-libva.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
 SCRIPT_COMMIT="181964965d0ab11d5fd680b722d4845fbc89f5a5"

--- a/scripts.d/50-vaapi/99-finalize.sh
+++ b/scripts.d/50-vaapi/99-finalize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_SKIP="1"
 

--- a/scripts.d/50-vidstab.sh
+++ b/scripts.d/50-vidstab.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/georgmartius/vid.stab.git"
 SCRIPT_COMMIT="05829db776069b7478dd2d90b6e0081668a41abc"

--- a/scripts.d/50-vulkan/45-vulkan.sh
+++ b/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
 SCRIPT_COMMIT="v1.3.274"

--- a/scripts.d/50-vulkan/50-shaderc.sh
+++ b/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
 SCRIPT_COMMIT="aaa44b544909600381e1a180074ed7f544e48410"

--- a/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
 SCRIPT_COMMIT="f349c91274b91c1a7c173f2df70ec53080076191"

--- a/scripts.d/50-vulkan/60-libplacebo.sh
+++ b/scripts.d/50-vulkan/60-libplacebo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libplacebo.git"
 SCRIPT_COMMIT="52314e0e435fbcb731e326815d4091ed0ba27475"

--- a/scripts.d/50-vulkan/99-enable.sh
+++ b/scripts.d/50-vulkan/99-enable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_SKIP="1"
 

--- a/scripts.d/50-x264.sh
+++ b/scripts.d/50-x264.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
 SCRIPT_COMMIT="c1c9931dc87289b8aeba78150467f17bdb97d019"

--- a/scripts.d/50-x265.sh
+++ b/scripts.d/50-x265.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
 SCRIPT_COMMIT="ce8642f22123f0b8cf105c88fc1e8af9888bd345"

--- a/scripts.d/50-xavs2.sh
+++ b/scripts.d/50-xavs2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/pkuvcl/xavs2.git"
 SCRIPT_COMMIT="eae1e8b9d12468059bdd7dee893508e470fa83d8"

--- a/scripts.d/50-xvid.sh
+++ b/scripts.d/50-xvid.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="http://svn.xvid.org/trunk/xvidcore"
 SCRIPT_REV="2198"

--- a/scripts.d/50-zimg.sh
+++ b/scripts.d/50-zimg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://github.com/sekrit-twc/zimg.git"
 SCRIPT_COMMIT="71431815950664f1e11b9ee4e5d4ba23d6d997f1"

--- a/scripts.d/50-zvbi.sh
+++ b/scripts.d/50-zvbi.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_REPO="https://svn.code.sf.net/p/zapping/svn/trunk/vbi"
 SCRIPT_REV="4270"

--- a/scripts.d/99-rpath.sh
+++ b/scripts.d/99-rpath.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_SKIP="1"
 

--- a/util/clean_cache.sh
+++ b/util/clean_cache.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 cd "$(dirname "$0")"/../.cache/downloads
 find . $(printf "! -name %s " $(find . -type l -exec basename -a {} + -exec readlink {} +)) -delete

--- a/util/dl_functions.sh
+++ b/util/dl_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 default_dl() {
     echo "git-mini-clone \"$SCRIPT_REPO\" \"$SCRIPT_COMMIT\" \"$1\""

--- a/util/get_dl_cache_tag.sh
+++ b/util/get_dl_cache_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 cd "$(dirname "$0")"
 ../download.sh hashonly | sha256sum | cut -d" " -f1

--- a/util/prunetags.sh
+++ b/util/prunetags.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 git fetch --tags
 TAGS=( $(git tag -l "autobuild-*" | sort -r) )

--- a/util/repack_latest.sh
+++ b/util/repack_latest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ $# -lt 2 ]]; then

--- a/util/run_stage.sh
+++ b/util/run_stage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 
 export RAW_CFLAGS="$CFLAGS"

--- a/util/update_scripts.sh
+++ b/util/update_scripts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 shopt -s globstar
 export LC_ALL=C

--- a/util/update_wiki.sh
+++ b/util/update_wiki.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ $# != 2 ]]; then

--- a/util/vars.sh
+++ b/util/vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $# -lt 2 ]]; then
     echo "Invalid Arguments"

--- a/variants/defaults-gpl-shared.sh
+++ b/variants/defaults-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh
 FF_CONFIGURE+=" --enable-shared --disable-static"

--- a/variants/defaults-lgpl-shared.sh
+++ b/variants/defaults-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh
 FF_CONFIGURE+=" --enable-shared --disable-static"

--- a/variants/dl-only.sh
+++ b/variants/dl-only.sh
@@ -1,1 +1,1 @@
-#!/bin/bash
+#!/usr/bin/env bash

--- a/variants/linux-install-shared.sh
+++ b/variants/linux-install-shared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"

--- a/variants/linux-install-static.sh
+++ b/variants/linux-install-static.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"

--- a/variants/linux64-gpl-shared.sh
+++ b/variants/linux64-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/linux64-gpl.sh
+++ b/variants/linux64-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/linux64-lgpl-shared.sh
+++ b/variants/linux64-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/linux64-lgpl.sh
+++ b/variants/linux64-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/linux64-nonfree-shared.sh
+++ b/variants/linux64-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux64-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/linux64-nonfree.sh
+++ b/variants/linux64-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux64-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/linuxarm64-gpl-shared.sh
+++ b/variants/linuxarm64-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/linuxarm64-gpl.sh
+++ b/variants/linuxarm64-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/linuxarm64-lgpl-shared.sh
+++ b/variants/linuxarm64-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/linuxarm64-lgpl.sh
+++ b/variants/linuxarm64-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linux-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/linuxarm64-nonfree-shared.sh
+++ b/variants/linuxarm64-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linuxarm64-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/linuxarm64-nonfree.sh
+++ b/variants/linuxarm64-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/linuxarm64-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/win32-gpl-shared.sh
+++ b/variants/win32-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/win32-gpl.sh
+++ b/variants/win32-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/win32-lgpl-shared.sh
+++ b/variants/win32-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/win32-lgpl.sh
+++ b/variants/win32-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/win32-nonfree-shared.sh
+++ b/variants/win32-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win32-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/win32-nonfree.sh
+++ b/variants/win32-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win32-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/win64-gpl-shared.sh
+++ b/variants/win64-gpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/win64-gpl.sh
+++ b/variants/win64-gpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/win64-lgpl-shared.sh
+++ b/variants/win64-lgpl-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-shared.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/win64-lgpl.sh
+++ b/variants/win64-lgpl.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/windows-install-static.sh
 source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/win64-nonfree-shared.sh
+++ b/variants/win64-nonfree-shared.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win64-gpl-shared.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/win64-nonfree.sh
+++ b/variants/win64-nonfree.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 source "$(dirname "$BASH_SOURCE")"/win64-gpl.sh
 FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
 LICENSE_FILE=""

--- a/variants/windows-install-shared.sh
+++ b/variants/windows-install-shared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"

--- a/variants/windows-install-static.sh
+++ b/variants/windows-install-static.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 package_variant() {
     IN="$1"


### PR DESCRIPTION
Taking a different approach this time. The updated shebang (to `#!/usr/bin/env bash`) will ensure better portability, to start. There will also be some conditionals to use different commands/options, where necessary.