### PR TITLE
Upgrade python3-distutils to python3-setuptools

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -11,7 +11,7 @@ RUN \
         gperf itstool ragel libc6-dev zlib1g-dev libssl-dev \
         gtk-doc-tools gobject-introspection gawk \
         ocaml ocamlbuild libnum-ocaml-dev indent p7zip-full \
-        python3-distutils python3-jinja2 python3-jsonschema python3-apt python-is-python3 && \
+        python3-setuptools python3-jinja2 python3-jsonschema python3-apt python-is-python3 && \
     apt-get -y clean && \
     git config --global user.email "builder@localhost" && \
     git config --global user.name "Builder" && \


### PR DESCRIPTION
[`distutils`](https://packages.ubuntu.com/noble/python3-distutils) (distutils package for Python 3.x) was deprecated a long time ago and will be removed in python 3.12. Upgrade to [`setuptools`](https://packages.ubuntu.com/noble/python3-setuptools) (Python3 Distutils Enhancements) instead.

See also https://bugs.launchpad.net/ubuntu/+source/python3-stdlib-extensions/+bug/2060772

Related to #361