### PR TITLE
Add missing release version addins to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ Available variants:
 * `nonfree-shared` Same again, but with the nonfree set of dependencies.
 
 All of those can be optionally combined with any combination of addins:
-* `4.4`/`5.0`/`5.1`/`6.0` to build from the respective release branch instead of master.
+* `4.4`/`5.0`/`5.1`/`6.0`/`6.1`/`7.0` to build from the respective release branch instead of master.
 * `debug` to not strip debug symbols from the binaries. This increases the output size by about 250MB.
 * `lto` build all dependencies and ffmpeg with -flto=auto (HIGHLY EXPERIMENTAL, broken for Windows, sometimes works for Linux)


### PR DESCRIPTION
Mostly to show support of targeting 7.0.

Cheers for your work on this!