### PR TITLE
Add support for targetting i686 GNU/Linux binaries

### DIFF
--- a/images/base-linux32/Dockerfile
+++ b/images/base-linux32/Dockerfile
@@ -1,0 +1,68 @@
+ARG GH_REPO=ghcr.io/fwgs/ffmpeg-builds
+FROM $GH_REPO/base:latest
+
+RUN --mount=src=ct-ng-config,dst=/.config \
+    git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    ./bootstrap && \
+    ./configure --enable-local && \
+    make -j$(nproc) && \
+    cp /.config .config && \
+    ./ct-ng build && \
+    cd / && \
+    rm -rf ct-ng
+
+# Prepare "cross" environment to heavily favour static builds
+RUN \
+    find /opt/ct-ng -type l \
+        -and -name '*.so' \
+        -and -not -ipath '*plugin*' \
+        -and -not -name 'libdl.*' \
+        -and -not -name 'libc.*' \
+        -and -not -name 'libm.*' \
+        -and -not -name 'libmvec.*' \
+        -and -not -name 'librt.*' \
+        -and -not -name 'libpthread.*' \
+        -delete && \
+    find /opt/ct-ng \
+        -name 'libdl.a' \
+        -or -name 'libc.a' \
+        -or -name 'libm.a' \
+        -or -name 'libmvec.a' \
+        -or -name 'librt.a' \
+        -or -name 'libpthread.a' \
+        -delete && \
+    mkdir /opt/ffbuild
+
+ENV FFBUILD_TOOLCHAIN=i686-ffbuild-linux-gnu \
+    FFBUILD_RUST_TARGET="i686-unknown-linux-gnu"
+
+#RUN \
+#    rustup default nightly && \
+#    echo "[unstable]\ntarget-applies-to-host = true\nhost-config = true\n" > "$CARGO_HOME"/config.toml && \
+#    echo "[target.$FFBUILD_RUST_TARGET]\nlinker = \"${FFBUILD_TOOLCHAIN}-gcc\"\nar = \"${FFBUILD_TOOLCHAIN}-gcc-ar\"\n" >> "$CARGO_HOME"/config.toml && \
+#    echo "[target.host]\nlinker = \"gcc\"\nar = \"ar\"\n" >> "$CARGO_HOME"/config.toml
+
+ADD toolchain.cmake /toolchain.cmake
+ADD cross.meson /cross.meson
+
+ADD gen-implib.sh /usr/bin/gen-implib
+RUN git clone --filter=blob:none --depth=1 https://github.com/yugr/Implib.so /opt/implib
+
+ENV PATH="/opt/ct-ng/bin:${PATH}" \
+    FFBUILD_TARGET_FLAGS="--pkg-config=pkg-config --cross-prefix=${FFBUILD_TOOLCHAIN}- --arch=i686 --target-os=linux" \
+    FFBUILD_CROSS_PREFIX="${FFBUILD_TOOLCHAIN}-" \
+    FFBUILD_PREFIX=/opt/ffbuild \
+    FFBUILD_CMAKE_TOOLCHAIN=/toolchain.cmake \
+    PKG_CONFIG=pkg-config \
+    PKG_CONFIG_LIBDIR=/opt/ffbuild/lib/pkgconfig:/opt/ffbuild/share/pkgconfig \
+    CC="${FFBUILD_TOOLCHAIN}-gcc" \
+    CXX="${FFBUILD_TOOLCHAIN}-g++" \
+    LD="${FFBUILD_TOOLCHAIN}-ld" \
+    AR="${FFBUILD_TOOLCHAIN}-gcc-ar" \
+    RANLIB="${FFBUILD_TOOLCHAIN}-gcc-ranlib" \
+    NM="${FFBUILD_TOOLCHAIN}-gcc-nm" \
+    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -pthread" \
+    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fstack-clash-protection -pthread" \
+    LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffbuild/lib -O2 -pipe -fstack-protector-strong -fstack-clash-protection -Wl,-z,relro,-z,now -pthread -lm" \
+    STAGE_CFLAGS="-fvisibility=hidden -fno-semantic-interposition" \
+    STAGE_CXXFLAGS="-fvisibility=hidden -fno-semantic-interposition"

--- a/images/base-linux32/cross.meson
+++ b/images/base-linux32/cross.meson
@@ -1,0 +1,13 @@
+[binaries]
+c = 'i686-ffbuild-linux-gnu-gcc'
+cpp = 'i686-ffbuild-linux-gnu-g++'
+ld = 'i686-ffbuild-linux-gnu-ld'
+ar = 'i686-ffbuild-linux-gnu-gcc-ar'
+ranlib = 'i686-ffbuild-linux-gnu-gcc-ranlib'
+strip = 'i686-ffbuild-linux-gnu-strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'x86'
+cpu = 'i686'
+endian = 'little'

--- a/images/base-linux32/ct-ng-config
+++ b/images/base-linux32/ct-ng-config
@@ -1,0 +1,1050 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# crosstool-NG 1.26.0.120_4d36f27 Configuration
+#
+CT_CONFIGURE_has_static_link=y
+CT_CONFIGURE_has_cxx11=y
+CT_CONFIGURE_has_wget=y
+CT_CONFIGURE_has_curl=y
+CT_CONFIGURE_has_meson=y
+CT_CONFIGURE_has_ninja=y
+CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_make_4_0_or_newer=y
+CT_CONFIGURE_has_make_4_4_or_newer=y
+CT_CONFIGURE_has_libtool_2_4_or_newer=y
+CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
+CT_CONFIGURE_has_autoconf_2_65_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
+CT_CONFIGURE_has_automake_1_15_or_newer=y
+CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
+CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_bison_3_0_4_or_newer=y
+CT_CONFIGURE_has_python=y
+CT_CONFIGURE_has_dtc=y
+CT_CONFIGURE_has_svn=y
+CT_CONFIGURE_has_git=y
+CT_CONFIGURE_has_md5sum=y
+CT_CONFIGURE_has_sha1sum=y
+CT_CONFIGURE_has_sha256sum=y
+CT_CONFIGURE_has_sha512sum=y
+CT_CONFIGURE_has_install_with_strip_program=y
+CT_VERSION="1.26.0.120_4d36f27"
+CT_VCHECK=""
+CT_CONFIG_VERSION_ENV="4"
+CT_CONFIG_VERSION_CURRENT="4"
+CT_CONFIG_VERSION="4"
+CT_MODULES=y
+
+#
+# Paths and misc options
+#
+
+#
+# crosstool-NG behavior
+#
+CT_OBSOLETE=y
+CT_EXPERIMENTAL=y
+CT_ALLOW_BUILD_AS_ROOT=y
+CT_ALLOW_BUILD_AS_ROOT_SURE=y
+# CT_ENABLE_EXPERIMENTAL_BUNDLED_PATCHES is not set
+# CT_DEBUG_CT is not set
+
+#
+# Paths
+#
+CT_LOCAL_TARBALLS_DIR="${HOME}/src"
+# CT_SAVE_TARBALLS is not set
+# CT_TARBALLS_BUILDROOT_LAYOUT is not set
+CT_WORK_DIR="${CT_TOP_DIR}/build"
+CT_BUILD_TOP_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_BUILD_DIR="${CT_BUILD_TOP_DIR}/build"
+CT_PREFIX_DIR="/opt/ct-ng"
+CT_RM_RF_PREFIX_DIR=y
+CT_REMOVE_DOCS=y
+# CT_INSTALL_LICENSES is not set
+# CT_PREFIX_DIR_RO is not set
+CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
+CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES=y
+# CT_TARBALL_RESULT is not set
+
+#
+# Downloading
+#
+CT_DOWNLOAD_AGENT_WGET=y
+# CT_DOWNLOAD_AGENT_CURL is not set
+# CT_DOWNLOAD_AGENT_NONE is not set
+# CT_FORBID_DOWNLOAD is not set
+# CT_FORCE_DOWNLOAD is not set
+CT_CONNECT_TIMEOUT=10
+CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
+# CT_ONLY_DOWNLOAD is not set
+# CT_USE_MIRROR is not set
+CT_VERIFY_DOWNLOAD_DIGEST=y
+CT_VERIFY_DOWNLOAD_DIGEST_SHA512=y
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA256 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA1 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_MD5 is not set
+CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
+# CT_VERIFY_DOWNLOAD_SIGNATURE is not set
+
+#
+# Extracting
+#
+# CT_FORCE_EXTRACT is not set
+CT_OVERRIDE_CONFIG_GUESS_SUB=y
+# CT_ONLY_EXTRACT is not set
+CT_PATCH_BUNDLED=y
+# CT_PATCH_LOCAL is not set
+# CT_PATCH_BUNDLED_LOCAL is not set
+# CT_PATCH_LOCAL_BUNDLED is not set
+# CT_PATCH_NONE is not set
+CT_PATCH_ORDER="bundled"
+
+#
+# Build behavior
+#
+CT_PARALLEL_JOBS=0
+CT_LOAD=""
+CT_USE_PIPES=y
+CT_EXTRA_CFLAGS_FOR_BUILD="-fPIC -DPIC"
+CT_EXTRA_CXXFLAGS_FOR_BUILD="-fPIC -DPIC"
+CT_EXTRA_LDFLAGS_FOR_BUILD=""
+CT_EXTRA_CFLAGS_FOR_HOST="-fPIC -DPIC"
+CT_EXTRA_LDFLAGS_FOR_HOST=""
+# CT_CONFIG_SHELL_SH is not set
+# CT_CONFIG_SHELL_ASH is not set
+CT_CONFIG_SHELL_BASH=y
+# CT_CONFIG_SHELL_CUSTOM is not set
+CT_CONFIG_SHELL="${bash}"
+
+#
+# Logging
+#
+# CT_LOG_ERROR is not set
+# CT_LOG_WARN is not set
+# CT_LOG_INFO is not set
+# CT_LOG_EXTRA is not set
+# CT_LOG_ALL is not set
+CT_LOG_DEBUG=y
+CT_LOG_LEVEL_MAX="DEBUG"
+# CT_LOG_SEE_TOOLS_WARN is not set
+# CT_LOG_TO_FILE is not set
+# end of Paths and misc options
+
+#
+# Target options
+#
+# CT_ARCH_ALPHA is not set
+# CT_ARCH_ARC is not set
+# CT_ARCH_ARM is not set
+# CT_ARCH_AVR is not set
+# CT_ARCH_BPF is not set
+# CT_ARCH_C6X is not set
+# CT_ARCH_LOONGARCH is not set
+# CT_ARCH_M68K is not set
+# CT_ARCH_MICROBLAZE is not set
+# CT_ARCH_MIPS is not set
+# CT_ARCH_MOXIE is not set
+# CT_ARCH_MSP430 is not set
+# CT_ARCH_NIOS2 is not set
+# CT_ARCH_PARISC is not set
+# CT_ARCH_POWERPC is not set
+# CT_ARCH_PRU is not set
+# CT_ARCH_RISCV is not set
+# CT_ARCH_S390 is not set
+# CT_ARCH_SH is not set
+# CT_ARCH_SPARC is not set
+CT_ARCH_X86=y
+# CT_ARCH_XTENSA is not set
+CT_ARCH="x86"
+CT_ARCH_CHOICE_KSYM="X86"
+CT_ARCH_CPU=""
+CT_ARCH_TUNE="core2"
+CT_ARCH_X86_SHOW=y
+
+#
+# Options for x86
+#
+CT_ARCH_X86_PKG_KSYM=""
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 PARISC POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
+CT_ARCH_SUFFIX=""
+# CT_OMIT_TARGET_VENDOR is not set
+
+#
+# Generic target options
+#
+# CT_MULTILIB is not set
+CT_DEMULTILIB=y
+CT_ARCH_USE_MMU=y
+CT_ARCH_SUPPORTS_LIBSANITIZER=y
+CT_ARCH_SUPPORTS_32=y
+CT_ARCH_SUPPORTS_64=y
+CT_ARCH_DEFAULT_32=y
+CT_ARCH_BITNESS=32
+CT_ARCH_32=y
+# CT_ARCH_64 is not set
+CT_ARCH_SUPPORTS_WITH_32_64=y
+
+#
+# Target optimisations
+#
+CT_ARCH_SUPPORTS_WITH_ARCH=y
+CT_ARCH_SUPPORTS_WITH_CPU=y
+CT_ARCH_SUPPORTS_WITH_TUNE=y
+CT_ARCH_ARCH="pentium-m"
+CT_TARGET_CFLAGS="-fPIC -DPIC"
+CT_TARGET_LDFLAGS=""
+# end of Target options
+
+#
+# Toolchain options
+#
+
+#
+# General toolchain options
+#
+CT_USE_SYSROOT=y
+CT_SYSROOT_NAME="sysroot"
+CT_SYSROOT_DIR_PREFIX=""
+# CT_STATIC_TOOLCHAIN is not set
+CT_SHOW_CT_VERSION=y
+CT_TOOLCHAIN_PKGVERSION=""
+CT_TOOLCHAIN_BUGURL=""
+
+#
+# Tuple completion and aliasing
+#
+CT_TARGET_VENDOR="ffbuild"
+CT_TARGET_ALIAS_SED_EXPR=""
+CT_TARGET_ALIAS=""
+
+#
+# Toolchain type
+#
+# CT_NATIVE is not set
+CT_CROSS=y
+# CT_CROSS_NATIVE is not set
+# CT_CANADIAN is not set
+CT_TOOLCHAIN_TYPE="cross"
+
+#
+# Build system
+#
+CT_BUILD=""
+CT_BUILD_PREFIX=""
+CT_BUILD_SUFFIX=""
+
+#
+# Misc options
+#
+# CT_TOOLCHAIN_ENABLE_NLS is not set
+# end of Toolchain options
+
+#
+# Operating System
+#
+CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+# CT_KERNEL_BARE_METAL is not set
+CT_KERNEL_LINUX=y
+# CT_KERNEL_WINDOWS is not set
+CT_KERNEL="linux"
+CT_KERNEL_CHOICE_KSYM="LINUX"
+CT_KERNEL_LINUX_SHOW=y
+
+#
+# Options for linux
+#
+CT_KERNEL_LINUX_PKG_KSYM="LINUX"
+CT_LINUX_DIR_NAME="linux"
+CT_LINUX_PKG_NAME="linux"
+CT_LINUX_SRC_RELEASE=y
+# CT_LINUX_SRC_DEVEL is not set
+# CT_LINUX_SRC_CUSTOM is not set
+CT_LINUX_PATCH_GLOBAL=y
+# CT_LINUX_PATCH_BUNDLED is not set
+# CT_LINUX_PATCH_LOCAL is not set
+# CT_LINUX_PATCH_BUNDLED_LOCAL is not set
+# CT_LINUX_PATCH_LOCAL_BUNDLED is not set
+# CT_LINUX_PATCH_NONE is not set
+CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_6_10 is not set
+# CT_LINUX_V_6_9 is not set
+# CT_LINUX_V_6_8 is not set
+# CT_LINUX_V_6_7 is not set
+# CT_LINUX_V_6_6 is not set
+# CT_LINUX_V_6_5 is not set
+# CT_LINUX_V_6_4 is not set
+# CT_LINUX_V_6_3 is not set
+# CT_LINUX_V_6_2 is not set
+# CT_LINUX_V_6_1 is not set
+# CT_LINUX_V_6_0 is not set
+# CT_LINUX_V_5_19 is not set
+# CT_LINUX_V_5_18 is not set
+# CT_LINUX_V_5_17 is not set
+# CT_LINUX_V_5_16 is not set
+# CT_LINUX_V_5_15 is not set
+# CT_LINUX_V_5_14 is not set
+# CT_LINUX_V_5_13 is not set
+# CT_LINUX_V_5_12 is not set
+# CT_LINUX_V_5_11 is not set
+# CT_LINUX_V_5_10 is not set
+# CT_LINUX_V_5_9 is not set
+# CT_LINUX_V_5_8 is not set
+# CT_LINUX_V_5_7 is not set
+# CT_LINUX_V_5_5 is not set
+# CT_LINUX_V_5_4 is not set
+# CT_LINUX_V_5_3 is not set
+# CT_LINUX_V_5_2 is not set
+# CT_LINUX_V_5_1 is not set
+# CT_LINUX_V_5_0 is not set
+# CT_LINUX_V_4_20 is not set
+# CT_LINUX_V_4_19 is not set
+CT_LINUX_V_4_18=y
+# CT_LINUX_V_4_17 is not set
+# CT_LINUX_V_4_16 is not set
+# CT_LINUX_V_4_15 is not set
+# CT_LINUX_V_4_14 is not set
+# CT_LINUX_V_4_13 is not set
+# CT_LINUX_V_4_12 is not set
+# CT_LINUX_V_4_11 is not set
+# CT_LINUX_V_4_10 is not set
+# CT_LINUX_V_4_9 is not set
+# CT_LINUX_V_4_4 is not set
+# CT_LINUX_V_4_1 is not set
+# CT_LINUX_V_3_18 is not set
+# CT_LINUX_V_3_16 is not set
+# CT_LINUX_V_3_13 is not set
+# CT_LINUX_V_3_12 is not set
+# CT_LINUX_V_3_10 is not set
+# CT_LINUX_V_3_4 is not set
+# CT_LINUX_V_3_2 is not set
+CT_LINUX_VERSION="4.18.20"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
+CT_LINUX_5_19_or_older=y
+CT_LINUX_older_than_5_19=y
+CT_LINUX_5_12_or_older=y
+CT_LINUX_older_than_5_12=y
+CT_LINUX_5_5_or_older=y
+CT_LINUX_older_than_5_5=y
+CT_LINUX_5_3_or_older=y
+CT_LINUX_older_than_5_3=y
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_LINUX_REQUIRE_3_2_or_later=y
+CT_KERNEL_has_rsync=y
+CT_KERNEL_DEP_RSYNC=y
+CT_KERNEL_LINUX_VERBOSITY_0=y
+# CT_KERNEL_LINUX_VERBOSITY_1 is not set
+# CT_KERNEL_LINUX_VERBOSITY_2 is not set
+CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+# CT_KERNEL_LINUX_INSTALL_CHECK is not set
+CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
+
+#
+# Common kernel options
+#
+CT_SHARED_LIBS=y
+# end of Operating System
+
+#
+# Binary utilities
+#
+CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS_BINUTILS=y
+CT_BINUTILS="binutils"
+CT_BINUTILS_CHOICE_KSYM="BINUTILS"
+CT_BINUTILS_BINUTILS_SHOW=y
+
+#
+# Options for binutils
+#
+CT_BINUTILS_BINUTILS_PKG_KSYM="BINUTILS"
+CT_BINUTILS_DIR_NAME="binutils"
+CT_BINUTILS_USE_GNU=y
+# CT_BINUTILS_USE_LINARO is not set
+# CT_BINUTILS_USE_ORACLE is not set
+CT_BINUTILS_USE="BINUTILS"
+CT_BINUTILS_PKG_NAME="binutils"
+CT_BINUTILS_SRC_RELEASE=y
+# CT_BINUTILS_SRC_DEVEL is not set
+# CT_BINUTILS_SRC_CUSTOM is not set
+CT_BINUTILS_PATCH_GLOBAL=y
+# CT_BINUTILS_PATCH_BUNDLED is not set
+# CT_BINUTILS_PATCH_LOCAL is not set
+# CT_BINUTILS_PATCH_BUNDLED_LOCAL is not set
+# CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
+# CT_BINUTILS_PATCH_NONE is not set
+CT_BINUTILS_PATCH_ORDER="global"
+CT_BINUTILS_V_2_43=y
+# CT_BINUTILS_V_2_42 is not set
+# CT_BINUTILS_V_2_41 is not set
+# CT_BINUTILS_V_2_40 is not set
+# CT_BINUTILS_V_2_39 is not set
+# CT_BINUTILS_V_2_38 is not set
+# CT_BINUTILS_V_2_37 is not set
+# CT_BINUTILS_V_2_36 is not set
+# CT_BINUTILS_V_2_35 is not set
+# CT_BINUTILS_V_2_34 is not set
+# CT_BINUTILS_V_2_33 is not set
+# CT_BINUTILS_V_2_32 is not set
+# CT_BINUTILS_V_2_31 is not set
+# CT_BINUTILS_V_2_30 is not set
+# CT_BINUTILS_V_2_29 is not set
+# CT_BINUTILS_V_2_28 is not set
+# CT_BINUTILS_V_2_27 is not set
+# CT_BINUTILS_V_2_26 is not set
+CT_BINUTILS_VERSION="2.43.1"
+CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
+CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
+CT_BINUTILS_later_than_2_39=y
+CT_BINUTILS_2_39_or_later=y
+CT_BINUTILS_later_than_2_30=y
+CT_BINUTILS_2_30_or_later=y
+CT_BINUTILS_later_than_2_27=y
+CT_BINUTILS_2_27_or_later=y
+CT_BINUTILS_later_than_2_26=y
+CT_BINUTILS_2_26_or_later=y
+
+#
+# GNU binutils
+#
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
+CT_BINUTILS_GOLD_SUPPORT=y
+CT_BINUTILS_FORCE_LD_BFD_DEFAULT=y
+CT_BINUTILS_LINKER_LD=y
+# CT_BINUTILS_LINKER_LD_GOLD is not set
+CT_BINUTILS_LINKERS_LIST="ld"
+CT_BINUTILS_LINKER_DEFAULT="bfd"
+CT_BINUTILS_PLUGINS=y
+CT_BINUTILS_RELRO=m
+CT_BINUTILS_DETERMINISTIC_ARCHIVES=y
+CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+# CT_BINUTILS_FOR_TARGET is not set
+CT_ALL_BINUTILS_CHOICES="BINUTILS"
+# end of Binary utilities
+
+#
+# C-library
+#
+CT_LIBC_GLIBC=y
+# CT_LIBC_MUSL is not set
+# CT_LIBC_UCLIBC_NG is not set
+CT_LIBC="glibc"
+CT_LIBC_CHOICE_KSYM="GLIBC"
+CT_LIBC_GLIBC_SHOW=y
+
+#
+# Options for glibc
+#
+CT_LIBC_GLIBC_PKG_KSYM="GLIBC"
+CT_GLIBC_DIR_NAME="glibc"
+CT_GLIBC_USE_GNU=y
+# CT_GLIBC_USE_ORACLE is not set
+CT_GLIBC_USE="GLIBC"
+CT_GLIBC_PKG_NAME="glibc"
+CT_GLIBC_SRC_RELEASE=y
+# CT_GLIBC_SRC_DEVEL is not set
+# CT_GLIBC_SRC_CUSTOM is not set
+CT_GLIBC_PATCH_GLOBAL=y
+# CT_GLIBC_PATCH_BUNDLED is not set
+# CT_GLIBC_PATCH_LOCAL is not set
+# CT_GLIBC_PATCH_BUNDLED_LOCAL is not set
+# CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
+# CT_GLIBC_PATCH_NONE is not set
+CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_40 is not set
+# CT_GLIBC_V_2_39 is not set
+# CT_GLIBC_V_2_38 is not set
+# CT_GLIBC_V_2_37 is not set
+# CT_GLIBC_V_2_36 is not set
+# CT_GLIBC_V_2_35 is not set
+# CT_GLIBC_V_2_34 is not set
+# CT_GLIBC_V_2_33 is not set
+# CT_GLIBC_V_2_32 is not set
+# CT_GLIBC_V_2_31 is not set
+# CT_GLIBC_V_2_30 is not set
+# CT_GLIBC_V_2_29 is not set
+CT_GLIBC_V_2_28=y
+# CT_GLIBC_V_2_27 is not set
+# CT_GLIBC_V_2_26 is not set
+# CT_GLIBC_V_2_25 is not set
+# CT_GLIBC_V_2_24 is not set
+# CT_GLIBC_V_2_23 is not set
+# CT_GLIBC_V_2_19 is not set
+# CT_GLIBC_V_2_17 is not set
+CT_GLIBC_VERSION="2.28"
+CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
+CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
+CT_GLIBC_2_38_or_older=y
+CT_GLIBC_older_than_2_38=y
+CT_GLIBC_2_37_or_older=y
+CT_GLIBC_older_than_2_37=y
+CT_GLIBC_2_36_or_older=y
+CT_GLIBC_older_than_2_36=y
+CT_GLIBC_2_34_or_older=y
+CT_GLIBC_older_than_2_34=y
+CT_GLIBC_2_32_or_older=y
+CT_GLIBC_older_than_2_32=y
+CT_GLIBC_2_31_or_older=y
+CT_GLIBC_older_than_2_31=y
+CT_GLIBC_2_30_or_older=y
+CT_GLIBC_older_than_2_30=y
+CT_GLIBC_2_29_or_older=y
+CT_GLIBC_older_than_2_29=y
+CT_GLIBC_2_28_or_later=y
+CT_GLIBC_2_28_or_older=y
+CT_GLIBC_later_than_2_27=y
+CT_GLIBC_2_27_or_later=y
+CT_GLIBC_later_than_2_26=y
+CT_GLIBC_2_26_or_later=y
+CT_GLIBC_later_than_2_25=y
+CT_GLIBC_2_25_or_later=y
+CT_GLIBC_later_than_2_24=y
+CT_GLIBC_2_24_or_later=y
+CT_GLIBC_later_than_2_23=y
+CT_GLIBC_2_23_or_later=y
+CT_GLIBC_later_than_2_20=y
+CT_GLIBC_2_20_or_later=y
+CT_GLIBC_later_than_2_17=y
+CT_GLIBC_2_17_or_later=y
+CT_GLIBC_later_than_2_14=y
+CT_GLIBC_2_14_or_later=y
+CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
+CT_GLIBC_DEP_BINUTILS=y
+CT_GLIBC_DEP_GCC=y
+CT_GLIBC_DEP_PYTHON=y
+CT_GLIBC_DEP_MAKE_4_3=y
+CT_GLIBC_SPARC_ALLOW_V7=y
+CT_THREADS="nptl"
+CT_GLIBC_BUILD_SSP=y
+CT_GLIBC_HAS_LIBIDN_ADDON=y
+# CT_GLIBC_USE_LIBIDN_ADDON is not set
+CT_GLIBC_NO_SPARC_V8=y
+CT_GLIBC_HAS_OBSOLETE_RPC=y
+CT_GLIBC_EXTRA_CONFIG_ARRAY="--with-pic"
+CT_GLIBC_CONFIGPARMS=""
+# CT_GLIBC_ENABLE_DEBUG is not set
+CT_GLIBC_EXTRA_CFLAGS="-fPIC -DPIC -no-pie"
+CT_GLIBC_ENABLE_OBSOLETE_RPC=y
+# CT_GLIBC_ENABLE_FORTIFIED_BUILD is not set
+# CT_GLIBC_DISABLE_VERSIONING is not set
+CT_GLIBC_OLDEST_ABI=""
+CT_GLIBC_FORCE_UNWIND=y
+# CT_GLIBC_LOCALES is not set
+# CT_GLIBC_KERNEL_VERSION_NONE is not set
+CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
+# CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
+CT_GLIBC_MIN_KERNEL="4.18.20"
+# CT_GLIBC_SSP_DEFAULT is not set
+# CT_GLIBC_SSP_NO is not set
+# CT_GLIBC_SSP_YES is not set
+# CT_GLIBC_SSP_ALL is not set
+CT_GLIBC_SSP_STRONG=y
+CT_GLIBC_SSP="strong"
+CT_GLIBC_ENABLE_COMMON_FLAG=y
+CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE PICOLIBC UCLIBC_NG"
+CT_LIBC_SUPPORT_THREADS_ANY=y
+CT_LIBC_SUPPORT_THREADS_NATIVE=y
+
+#
+# Common C library options
+#
+CT_THREADS_NATIVE=y
+# CT_CREATE_LDSO_CONF is not set
+CT_LIBC_XLDD=y
+# end of C-library
+
+#
+# C compiler
+#
+CT_CC_CORE_NEEDED=y
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_D=y
+CT_CC_SUPPORT_JIT=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+CT_CC_GCC=y
+CT_CC="gcc"
+CT_CC_CHOICE_KSYM="GCC"
+CT_CC_GCC_SHOW=y
+
+#
+# Options for gcc
+#
+CT_CC_GCC_PKG_KSYM="GCC"
+CT_GCC_DIR_NAME="gcc"
+CT_GCC_USE_GNU=y
+# CT_GCC_USE_LINARO is not set
+# CT_GCC_USE_ORACLE is not set
+CT_GCC_USE="GCC"
+CT_GCC_PKG_NAME="gcc"
+CT_GCC_SRC_RELEASE=y
+# CT_GCC_SRC_DEVEL is not set
+# CT_GCC_SRC_CUSTOM is not set
+CT_GCC_PATCH_GLOBAL=y
+# CT_GCC_PATCH_BUNDLED is not set
+# CT_GCC_PATCH_LOCAL is not set
+# CT_GCC_PATCH_BUNDLED_LOCAL is not set
+# CT_GCC_PATCH_LOCAL_BUNDLED is not set
+# CT_GCC_PATCH_NONE is not set
+CT_GCC_PATCH_ORDER="global"
+CT_GCC_V_14=y
+# CT_GCC_V_13 is not set
+# CT_GCC_V_12 is not set
+# CT_GCC_V_11 is not set
+# CT_GCC_V_10 is not set
+# CT_GCC_V_9 is not set
+# CT_GCC_V_8 is not set
+# CT_GCC_V_7 is not set
+# CT_GCC_V_6 is not set
+# CT_GCC_V_5 is not set
+# CT_GCC_V_4_9 is not set
+CT_GCC_VERSION="14.2.0"
+CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
+CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_later_than_14=y
+CT_GCC_14_or_later=y
+CT_GCC_later_than_13=y
+CT_GCC_13_or_later=y
+CT_GCC_later_than_12=y
+CT_GCC_12_or_later=y
+CT_GCC_later_than_11=y
+CT_GCC_11_or_later=y
+CT_GCC_later_than_10=y
+CT_GCC_10_or_later=y
+CT_GCC_later_than_9=y
+CT_GCC_9_or_later=y
+CT_GCC_later_than_8=y
+CT_GCC_8_or_later=y
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_REQUIRE_4_9_or_later=y
+CT_CC_GCC_ENABLE_PLUGINS=y
+CT_CC_GCC_HAS_LIBMPX=y
+CT_CC_GCC_ENABLE_CXX_FLAGS=""
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-host-shared --enable-default-ssp"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--enable-host-shared --enable-default-ssp --with-build-config=bootstrap-lto-lean --enable-link-serialization=2"
+# CT_CC_GCC_STATIC_LIBSTDCXX is not set
+# CT_CC_GCC_SYSTEM_ZLIB is not set
+CT_CC_GCC_CONFIG_TLS=m
+
+#
+# Optimisation features
+#
+CT_CC_GCC_USE_GRAPHITE=y
+CT_CC_GCC_USE_LTO=y
+CT_CC_GCC_LTO_ZSTD=m
+
+#
+# Settings for libraries running on target
+#
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+# CT_CC_GCC_ENABLE_TARGET_OPTSPACE is not set
+# CT_CC_GCC_LIBMUDFLAP is not set
+CT_CC_GCC_LIBGOMP=y
+CT_CC_GCC_LIBSSP=m
+# CT_CC_GCC_LIBQUADMATH is not set
+# CT_CC_GCC_LIBSANITIZER is not set
+# CT_CC_GCC_LIBMPX is not set
+# CT_CC_GCC_LIBSTDCXX_VERBOSE is not set
+
+#
+# Misc. obscure options.
+#
+CT_CC_CXA_ATEXIT=y
+CT_CC_GCC_TM_CLONE_REGISTRY=m
+# CT_CC_GCC_DISABLE_PCH is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
+CT_CC_GCC_LDBL_128=m
+# CT_CC_GCC_BUILD_ID is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
+# CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
+# CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
+CT_CC_GCC_DEC_FLOATS_AUTO=y
+# CT_CC_GCC_DEC_FLOATS_BID is not set
+# CT_CC_GCC_DEC_FLOATS_DPD is not set
+# CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_CC_GCC_DEC_FLOATS=""
+CT_ALL_CC_CHOICES="GCC"
+
+#
+# Additional supported languages:
+#
+CT_CC_LANG_CXX=y
+# CT_CC_LANG_FORTRAN is not set
+# CT_CC_LANG_JIT is not set
+# CT_CC_LANG_ADA is not set
+# CT_CC_LANG_D is not set
+# CT_CC_LANG_OBJC is not set
+# CT_CC_LANG_OBJCXX is not set
+# CT_CC_LANG_GOLANG is not set
+CT_CC_LANG_OTHERS=""
+# end of C compiler
+
+#
+# Linkers
+#
+
+#
+# BFD enabled in binutils
+#
+# CT_LINKER_MOLD is not set
+CT_ALL_LINKER_CHOICES="MOLD"
+# end of Linkers
+
+#
+# Debug facilities
+#
+# CT_DEBUG_DUMA is not set
+# CT_DEBUG_GDB is not set
+# CT_DEBUG_LTRACE is not set
+# CT_DEBUG_STRACE is not set
+CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
+# end of Debug facilities
+
+#
+# Companion libraries
+#
+# CT_COMPLIBS_CHECK is not set
+# CT_COMP_LIBS_CLOOG is not set
+# CT_COMP_LIBS_EXPAT is not set
+CT_COMP_LIBS_GETTEXT=y
+CT_COMP_LIBS_GETTEXT_PKG_KSYM="GETTEXT"
+CT_GETTEXT_DIR_NAME="gettext"
+CT_GETTEXT_PKG_NAME="gettext"
+CT_GETTEXT_SRC_RELEASE=y
+# CT_GETTEXT_SRC_DEVEL is not set
+# CT_GETTEXT_SRC_CUSTOM is not set
+CT_GETTEXT_PATCH_GLOBAL=y
+# CT_GETTEXT_PATCH_BUNDLED is not set
+# CT_GETTEXT_PATCH_LOCAL is not set
+# CT_GETTEXT_PATCH_BUNDLED_LOCAL is not set
+# CT_GETTEXT_PATCH_LOCAL_BUNDLED is not set
+# CT_GETTEXT_PATCH_NONE is not set
+CT_GETTEXT_PATCH_ORDER="global"
+CT_GETTEXT_V_0_22_5=y
+# CT_GETTEXT_V_0_21 is not set
+# CT_GETTEXT_V_0_20_1 is not set
+# CT_GETTEXT_V_0_19_8_1 is not set
+CT_GETTEXT_VERSION="0.22.5"
+CT_GETTEXT_MIRRORS="$(CT_Mirrors GNU gettext)"
+CT_GETTEXT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GETTEXT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GETTEXT_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GETTEXT_SIGNATURE_FORMAT="packed/.sig"
+CT_GETTEXT_later_than_0_21=y
+CT_GETTEXT_0_21_or_later=y
+CT_GETTEXT_INCOMPATIBLE_WITH_UCLIBC_NG=y
+
+#
+# This version of gettext is not compatible with uClibc-NG. Select
+#
+
+#
+# a different version if uClibc-NG is used on the target or (in a
+#
+
+#
+# Canadian cross build) on the host.
+#
+CT_COMP_LIBS_GMP=y
+CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
+CT_GMP_DIR_NAME="gmp"
+CT_GMP_PKG_NAME="gmp"
+CT_GMP_SRC_RELEASE=y
+# CT_GMP_SRC_DEVEL is not set
+# CT_GMP_SRC_CUSTOM is not set
+CT_GMP_PATCH_GLOBAL=y
+# CT_GMP_PATCH_BUNDLED is not set
+# CT_GMP_PATCH_LOCAL is not set
+# CT_GMP_PATCH_BUNDLED_LOCAL is not set
+# CT_GMP_PATCH_LOCAL_BUNDLED is not set
+# CT_GMP_PATCH_NONE is not set
+CT_GMP_PATCH_ORDER="global"
+CT_GMP_V_6_2=y
+# CT_GMP_V_6_1 is not set
+CT_GMP_VERSION="6.2.1"
+CT_GMP_MIRRORS="https://gmplib.org/download/gmp https://gmplib.org/download/gmp/archive $(CT_Mirrors GNU gmp)"
+CT_GMP_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GMP_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GMP_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2"
+CT_GMP_SIGNATURE_FORMAT="packed/.sig"
+CT_COMP_LIBS_ISL=y
+CT_COMP_LIBS_ISL_PKG_KSYM="ISL"
+CT_ISL_DIR_NAME="isl"
+CT_ISL_PKG_NAME="isl"
+CT_ISL_SRC_RELEASE=y
+# CT_ISL_SRC_DEVEL is not set
+# CT_ISL_SRC_CUSTOM is not set
+CT_ISL_PATCH_GLOBAL=y
+# CT_ISL_PATCH_BUNDLED is not set
+# CT_ISL_PATCH_LOCAL is not set
+# CT_ISL_PATCH_BUNDLED_LOCAL is not set
+# CT_ISL_PATCH_LOCAL_BUNDLED is not set
+# CT_ISL_PATCH_NONE is not set
+CT_ISL_PATCH_ORDER="global"
+CT_ISL_V_0_26=y
+# CT_ISL_V_0_25 is not set
+# CT_ISL_V_0_24 is not set
+# CT_ISL_V_0_23 is not set
+# CT_ISL_V_0_22 is not set
+# CT_ISL_V_0_21 is not set
+# CT_ISL_V_0_20 is not set
+# CT_ISL_V_0_19 is not set
+# CT_ISL_V_0_18 is not set
+# CT_ISL_V_0_17 is not set
+# CT_ISL_V_0_16 is not set
+# CT_ISL_V_0_15 is not set
+CT_ISL_VERSION="0.26"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
+CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_ISL_SIGNATURE_FORMAT=""
+CT_ISL_later_than_0_18=y
+CT_ISL_0_18_or_later=y
+CT_ISL_later_than_0_15=y
+CT_ISL_0_15_or_later=y
+# CT_COMP_LIBS_LIBELF is not set
+CT_COMP_LIBS_LIBICONV=y
+CT_COMP_LIBS_LIBICONV_PKG_KSYM="LIBICONV"
+CT_LIBICONV_DIR_NAME="libiconv"
+CT_LIBICONV_PKG_NAME="libiconv"
+CT_LIBICONV_SRC_RELEASE=y
+# CT_LIBICONV_SRC_DEVEL is not set
+# CT_LIBICONV_SRC_CUSTOM is not set
+CT_LIBICONV_PATCH_GLOBAL=y
+# CT_LIBICONV_PATCH_BUNDLED is not set
+# CT_LIBICONV_PATCH_LOCAL is not set
+# CT_LIBICONV_PATCH_BUNDLED_LOCAL is not set
+# CT_LIBICONV_PATCH_LOCAL_BUNDLED is not set
+# CT_LIBICONV_PATCH_NONE is not set
+CT_LIBICONV_PATCH_ORDER="global"
+CT_LIBICONV_V_1_16=y
+# CT_LIBICONV_V_1_15 is not set
+CT_LIBICONV_VERSION="1.16"
+CT_LIBICONV_MIRRORS="$(CT_Mirrors GNU libiconv)"
+CT_LIBICONV_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_LIBICONV_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_LIBICONV_ARCHIVE_FORMATS=".tar.gz"
+CT_LIBICONV_SIGNATURE_FORMAT="packed/.sig"
+CT_COMP_LIBS_MPC=y
+CT_COMP_LIBS_MPC_PKG_KSYM="MPC"
+CT_MPC_DIR_NAME="mpc"
+CT_MPC_PKG_NAME="mpc"
+CT_MPC_SRC_RELEASE=y
+# CT_MPC_SRC_DEVEL is not set
+# CT_MPC_SRC_CUSTOM is not set
+CT_MPC_PATCH_GLOBAL=y
+# CT_MPC_PATCH_BUNDLED is not set
+# CT_MPC_PATCH_LOCAL is not set
+# CT_MPC_PATCH_BUNDLED_LOCAL is not set
+# CT_MPC_PATCH_LOCAL_BUNDLED is not set
+# CT_MPC_PATCH_NONE is not set
+CT_MPC_PATCH_ORDER="global"
+CT_MPC_V_1_3=y
+# CT_MPC_V_1_2 is not set
+CT_MPC_VERSION="1.3.1"
+CT_MPC_MIRRORS="https://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
+CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPC_ARCHIVE_FORMATS=".tar.gz"
+CT_MPC_SIGNATURE_FORMAT="packed/.sig"
+CT_MPC_later_than_1_1_0=y
+CT_MPC_1_1_0_or_later=y
+CT_COMP_LIBS_MPFR=y
+CT_COMP_LIBS_MPFR_PKG_KSYM="MPFR"
+CT_MPFR_DIR_NAME="mpfr"
+CT_MPFR_PKG_NAME="mpfr"
+CT_MPFR_SRC_RELEASE=y
+# CT_MPFR_SRC_DEVEL is not set
+# CT_MPFR_SRC_CUSTOM is not set
+CT_MPFR_PATCH_GLOBAL=y
+# CT_MPFR_PATCH_BUNDLED is not set
+# CT_MPFR_PATCH_LOCAL is not set
+# CT_MPFR_PATCH_BUNDLED_LOCAL is not set
+# CT_MPFR_PATCH_LOCAL_BUNDLED is not set
+# CT_MPFR_PATCH_NONE is not set
+CT_MPFR_PATCH_ORDER="global"
+CT_MPFR_V_4_2=y
+CT_MPFR_VERSION="4.2.1"
+CT_MPFR_MIRRORS="https://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
+CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
+CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
+CT_MPFR_later_than_4_0_0=y
+CT_MPFR_4_0_0_or_later=y
+CT_COMP_LIBS_NCURSES=y
+CT_COMP_LIBS_NCURSES_PKG_KSYM="NCURSES"
+CT_NCURSES_DIR_NAME="ncurses"
+CT_NCURSES_PKG_NAME="ncurses"
+CT_NCURSES_SRC_RELEASE=y
+# CT_NCURSES_SRC_DEVEL is not set
+# CT_NCURSES_SRC_CUSTOM is not set
+CT_NCURSES_PATCH_GLOBAL=y
+# CT_NCURSES_PATCH_BUNDLED is not set
+# CT_NCURSES_PATCH_LOCAL is not set
+# CT_NCURSES_PATCH_BUNDLED_LOCAL is not set
+# CT_NCURSES_PATCH_LOCAL_BUNDLED is not set
+# CT_NCURSES_PATCH_NONE is not set
+CT_NCURSES_PATCH_ORDER="global"
+CT_NCURSES_V_6_4=y
+# CT_NCURSES_V_6_2 is not set
+# CT_NCURSES_V_6_1 is not set
+# CT_NCURSES_V_6_0 is not set
+CT_NCURSES_VERSION="6.4"
+CT_NCURSES_MIRRORS="https://invisible-mirror.net/archives/ncurses $(CT_Mirrors GNU ncurses)"
+CT_NCURSES_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_NCURSES_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_NCURSES_ARCHIVE_FORMATS=".tar.gz"
+CT_NCURSES_SIGNATURE_FORMAT="packed/.sig"
+# CT_NCURSES_NEW_ABI is not set
+CT_NCURSES_HOST_CONFIG_ARGS=""
+CT_NCURSES_HOST_DISABLE_DB=y
+CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100"
+CT_NCURSES_TARGET_CONFIG_ARGS=""
+# CT_NCURSES_TARGET_DISABLE_DB is not set
+CT_NCURSES_TARGET_FALLBACKS=""
+CT_COMP_LIBS_ZLIB=y
+CT_COMP_LIBS_ZLIB_PKG_KSYM="ZLIB"
+CT_ZLIB_DIR_NAME="zlib"
+CT_ZLIB_PKG_NAME="zlib"
+CT_ZLIB_SRC_RELEASE=y
+# CT_ZLIB_SRC_DEVEL is not set
+# CT_ZLIB_SRC_CUSTOM is not set
+CT_ZLIB_PATCH_GLOBAL=y
+# CT_ZLIB_PATCH_BUNDLED is not set
+# CT_ZLIB_PATCH_LOCAL is not set
+# CT_ZLIB_PATCH_BUNDLED_LOCAL is not set
+# CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
+# CT_ZLIB_PATCH_NONE is not set
+CT_ZLIB_PATCH_ORDER="global"
+CT_ZLIB_V_1_3=y
+# CT_ZLIB_V_1_2_13 is not set
+CT_ZLIB_VERSION="1.3"
+CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
+CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
+CT_COMP_LIBS_ZSTD=y
+CT_COMP_LIBS_ZSTD_PKG_KSYM="ZSTD"
+CT_ZSTD_DIR_NAME="zstd"
+CT_ZSTD_PKG_NAME="zstd"
+CT_ZSTD_SRC_RELEASE=y
+# CT_ZSTD_SRC_DEVEL is not set
+# CT_ZSTD_SRC_CUSTOM is not set
+CT_ZSTD_PATCH_GLOBAL=y
+# CT_ZSTD_PATCH_BUNDLED is not set
+# CT_ZSTD_PATCH_LOCAL is not set
+# CT_ZSTD_PATCH_BUNDLED_LOCAL is not set
+# CT_ZSTD_PATCH_LOCAL_BUNDLED is not set
+# CT_ZSTD_PATCH_NONE is not set
+CT_ZSTD_PATCH_ORDER="global"
+CT_ZSTD_V_1_5_6=y
+# CT_ZSTD_V_1_5_5 is not set
+# CT_ZSTD_V_1_5_2 is not set
+CT_ZSTD_VERSION="1.5.6"
+CT_ZSTD_MIRRORS="https://github.com/facebook/zstd/releases/download/v${CT_ZSTD_VERSION} https://www.zstd.net/"
+CT_ZSTD_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_FORMATS=".tar.gz"
+CT_ZSTD_SIGNATURE_FORMAT="packed/.sig"
+CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB ZSTD"
+CT_LIBICONV_NEEDED=y
+CT_GETTEXT_NEEDED=y
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_MPC_NEEDED=y
+CT_NCURSES_NEEDED=y
+CT_ZLIB_NEEDED=y
+CT_ZSTD_NEEDED=y
+CT_LIBICONV=y
+CT_GETTEXT=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_MPC=y
+CT_NCURSES=y
+CT_ZLIB=y
+CT_ZSTD=y
+# end of Companion libraries
+
+#
+# Companion tools
+#
+# CT_COMP_TOOLS_FOR_HOST is not set
+# CT_COMP_TOOLS_AUTOCONF is not set
+# CT_COMP_TOOLS_AUTOMAKE is not set
+# CT_COMP_TOOLS_BISON is not set
+# CT_COMP_TOOLS_DTC is not set
+# CT_COMP_TOOLS_LIBTOOL is not set
+# CT_COMP_TOOLS_M4 is not set
+CT_COMP_TOOLS_MAKE=y
+CT_COMP_TOOLS_MAKE_PKG_KSYM="MAKE"
+CT_MAKE_DIR_NAME="make"
+CT_MAKE_PKG_NAME="make"
+CT_MAKE_SRC_RELEASE=y
+# CT_MAKE_SRC_DEVEL is not set
+# CT_MAKE_SRC_CUSTOM is not set
+CT_MAKE_PATCH_GLOBAL=y
+# CT_MAKE_PATCH_BUNDLED is not set
+# CT_MAKE_PATCH_LOCAL is not set
+# CT_MAKE_PATCH_BUNDLED_LOCAL is not set
+# CT_MAKE_PATCH_LOCAL_BUNDLED is not set
+# CT_MAKE_PATCH_NONE is not set
+CT_MAKE_PATCH_ORDER="global"
+CT_MAKE_V_4_3=y
+# CT_MAKE_V_4_2 is not set
+CT_MAKE_VERSION="4.3"
+CT_MAKE_MIRRORS="$(CT_Mirrors GNU make)"
+CT_MAKE_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MAKE_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MAKE_ARCHIVE_FORMATS=".tar.lz .tar.gz"
+CT_MAKE_SIGNATURE_FORMAT="packed/.sig"
+CT_MAKE_4_4_or_older=y
+CT_MAKE_older_than_4_4=y
+CT_MAKE_REQUIRE_older_than_4_4=y
+CT_MAKE_4_3_or_later=y
+CT_MAKE_4_3_or_older=y
+CT_MAKE_GMAKE_SYMLINK=y
+CT_MAKE_GNUMAKE_SYMLINK=y
+CT_ALL_COMP_TOOLS_CHOICES="AUTOCONF AUTOMAKE BISON DTC LIBTOOL M4 MAKE"
+# end of Companion tools
+
+#
+# Test suite
+#
+# CT_TEST_SUITE_GCC is not set
+# end of Test suite

--- a/images/base-linux32/gen-implib.sh
+++ b/images/base-linux32/gen-implib.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+if [[ $# != 2 ]]; then
+    echo "Invalid arguments"
+    exit 1
+fi
+IN="$1"
+OUT="$2"
+
+TMPDIR="$(mktemp -d)"
+trap "rm -rf '$TMPDIR'" EXIT
+cd "$TMPDIR"
+
+set -x
+python3 /opt/implib/implib-gen.py --target i686-linux-gnu --dlopen --lazy-load --verbose "$IN"
+${FFBUILD_CROSS_PREFIX}gcc $CFLAGS $STAGE_CFLAGS -Wa,--noexecstack -DIMPLIB_HIDDEN_SHIMS -c *.tramp.S *.init.c
+${FFBUILD_CROSS_PREFIX}ar -rcs "$OUT" *.tramp.o *.init.o

--- a/images/base-linux32/toolchain.cmake
+++ b/images/base-linux32/toolchain.cmake
@@ -1,0 +1,17 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR i686)
+set(CMAKE_SYSTEM_VERSION 4.18.20)
+
+set(triple i686-ffbuild-linux-gnu)
+
+set(CMAKE_C_COMPILER ${triple}-gcc)
+set(CMAKE_CXX_COMPILER ${triple}-g++)
+set(CMAKE_RANLIB ${triple}-gcc-ranlib)
+set(CMAKE_AR ${triple}-gcc-ar)
+
+set(CMAKE_SYSROOT /opt/ct-ng/${triple}/sysroot)
+set(CMAKE_FIND_ROOT_PATH /opt/ct-ng /opt/ct-ng/${triple}/sysroot /opt/ffbuild)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/variants/linux32-gpl-shared.sh
+++ b/variants/linux32-gpl-shared.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-gpl-shared.sh

--- a/variants/linux32-gpl.sh
+++ b/variants/linux32-gpl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/linux-install-static.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/variants/linux32-lgpl-shared.sh
+++ b/variants/linux32-lgpl-shared.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/linux-install-shared.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-lgpl-shared.sh

--- a/variants/linux32-lgpl.sh
+++ b/variants/linux32-lgpl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/linux-install-static.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-lgpl.sh

--- a/variants/linux32-nonfree-shared.sh
+++ b/variants/linux32-nonfree-shared.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/linux32-gpl-shared.sh
+FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"

--- a/variants/linux32-nonfree.sh
+++ b/variants/linux32-nonfree.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/linux32-gpl.sh
+FF_CONFIGURE="--enable-nonfree $FF_CONFIGURE"
+LICENSE_FILE=""


### PR DESCRIPTION
To match `linux64` it's called `linux32`.