### PR TITLE
Generate checksum files for artifacts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,14 @@ cd -
 
 rm -rf ffbuild
 
+cd "${ARTIFACTS_PATH}" &&
+(
+    for bits in 512 256; do
+        ext="sha${bits}"
+        ${ext}sum --binary "${OUTPUT_FNAME}" >| "${OUTPUT_FNAME}.${ext}"
+    done
+)
+
 if [[ -n "$GITHUB_ACTIONS" ]]; then
     echo "build_name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
     echo "${OUTPUT_FNAME}" > "${ARTIFACTS_PATH}/${TARGET}-${VARIANT}${ADDINS_STR:+-}${ADDINS_STR}.txt"

--- a/build.sh
+++ b/build.sh
@@ -78,10 +78,10 @@ rm -rf ffbuild
 
 cd "${ARTIFACTS_PATH}" &&
 (
-    for bits in 512 256; do
+    for bits in 512 384 256; do
         ext="sha${bits}"
-        ${ext}sum --binary "${OUTPUT_FNAME}" >| "${OUTPUT_FNAME}.${ext}"
-    done
+        ${ext}sum --binary --tag "${OUTPUT_FNAME}"
+    done >| "${OUTPUT_FNAME}.sums"
 )
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then


### PR DESCRIPTION
This makes it much nicer for anyone using Docker to download an archive using `ADD`.

See the documentation: https://docs.docker.com/reference/dockerfile/#add---checksum

Also, anyone else who needs to verify the built file doesn't need to download it, then generate their own checksum.