### PR TITLE
Disable asm for libtheora on win64

### DIFF
--- a/scripts.d/50-libtheora.sh
+++ b/scripts.d/50-libtheora.sh
@@ -31,6 +31,12 @@ ffbuild_dockerbuild() {
         return -1
     fi
 
+    if [[ $TARGET == win64 ]]; then
+        myconf+=(
+            --disable-asm
+        )
+    fi
+
     ./configure "${myconf[@]}"
     make -j$(nproc)
     make install


### PR DESCRIPTION
Builds for Windows have a broken libtheora encoder. I was already aware that libtheora asm optimizations are incompatible with Windows 64bits due to a difference in the callee/called register convention that doesn't happen on other platforms.

Videos encoded to OGV/Theora play with many visual glitches, stutter, corrupted display. ffplay shows the error `[theora @ 0x7f98cc1d2000] error in unpack_block_qpis` for almost every frame. See https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/20185 for more info.

This is another hint at the issue: https://github.com/rdp/ffmpeg-windows-build-helpers/blob/083f55b7cbad2fb4339dca9ef26fe4f647abeeb4/cross_compile_ffmpeg.sh#L1357

I couldn't test the fix because I've been unable to rebuild FFmpeg with this PR. The linked libtheora is always an older prebuilt version. I'm sorry but I don't know how to update it.