### PR TITLE
Fix build process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,7 @@ docker run --rm -i $TTY_ARG "${UIDARGS[@]}" -v "$PWD/ffbuild":/ffbuild -v "$BUIL
 if [[ -n "$FFBUILD_OUTPUT_DIR" ]]; then
     mkdir -p "$FFBUILD_OUTPUT_DIR"
     package_variant ffbuild/prefix "$FFBUILD_OUTPUT_DIR"
+    [[ -n "$LICENSE_FILE" ]] && cp "ffbuild/ffmpeg/$LICENSE_FILE" "$FFBUILD_OUTPUT_DIR/LICENSE"
     rm -rf ffbuild
     exit 0
 fi
@@ -61,9 +62,7 @@ BUILD_NAME="ffmpeg-$(./ffbuild/ffmpeg/ffbuild/version.sh ffbuild/ffmpeg)-${TARGE
 
 mkdir -p "ffbuild/pkgroot/$BUILD_NAME"
 package_variant ffbuild/prefix "ffbuild/pkgroot/$BUILD_NAME"
-
-[[ -n "$LICENSE_FILE" ]] && cp "ffbuild/ffmpeg/$LICENSE_FILE" "ffbuild/pkgroot/$BUILD_NAME/LICENSE.txt"
-
+[[ -n "$LICENSE_FILE" ]] && cp "ffbuild/ffmpeg/$LICENSE_FILE" "ffbuild/pkgroot/$BUILD_NAME/LICENSE"
 cd ffbuild/pkgroot
 if [[ "${TARGET}" == win* ]]; then
     OUTPUT_FNAME="${BUILD_NAME}.zip"

--- a/variants/linux-install-shared.sh
+++ b/variants/linux-install-shared.sh
@@ -26,4 +26,7 @@ package_variant() {
 
     mkdir -p "$OUT/man"
     cp -r "$IN"/share/man/* "$OUT"/man
+
+    mkdir -p "$OUT/presets"
+    cp "$IN"/share/ffmpeg/*.ffpreset "$OUT"/presets
 }

--- a/variants/linux-install-static.sh
+++ b/variants/linux-install-static.sh
@@ -12,4 +12,7 @@ package_variant() {
 
     mkdir -p "$OUT/man"
     cp -r "$IN"/share/man/* "$OUT"/man
+
+    mkdir -p "$OUT/presets"
+    cp "$IN"/share/ffmpeg/*.ffpreset "$OUT"/presets
 }

--- a/variants/windows-install-shared.sh
+++ b/variants/windows-install-shared.sh
@@ -24,4 +24,7 @@ package_variant() {
 
     mkdir -p "$OUT"/doc
     cp -r "$IN"/share/doc/ffmpeg/* "$OUT"/doc
+
+    mkdir -p "$OUT/presets"
+    cp "$IN"/share/ffmpeg/*.ffpreset "$OUT"/presets
 }

--- a/variants/windows-install-static.sh
+++ b/variants/windows-install-static.sh
@@ -9,4 +9,7 @@ package_variant() {
 
     mkdir -p "$OUT/doc"
     cp -r "$IN"/share/doc/ffmpeg/* "$OUT"/doc
+
+    mkdir -p "$OUT/presets"
+    cp "$IN"/share/ffmpeg/*.ffpreset "$OUT"/presets
 }


### PR DESCRIPTION
- The **presets** folder is now included in the build output
- Fixed an issue where license file could **not** be copied when the **FFBUILD_OUTPUT_DIR** variable was present
- The name of the license file has been changed to **LICENSE**