### PR TITLE
Fix URLs in 20-libiconv.sh script

### DIFF
--- a/scripts.d/20-libiconv.sh
+++ b/scripts.d/20-libiconv.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://git.savannah.gnu.org/git/libiconv.git"
-SCRIPT_MIRROR="git://git.savannah.gnu.org/libiconv.git"
+SCRIPT_REPO="https://https.git.savannah.gnu.org/git/libiconv.git"
+SCRIPT_MIRROR="git://git.git.savannah.gnu.org/libiconv.git"
 SCRIPT_COMMIT="61fbe742a3702e5030f8258ad130a847d6c3e89a"
 
-SCRIPT_REPO2="https://git.savannah.gnu.org/git/gnulib.git"
+SCRIPT_REPO2="https://https.git.savannah.gnu.org/git/gnulib.git"
 SCRIPT_MIRROR2="https://github.com/coreutils/gnulib.git"
 SCRIPT_COMMIT2="ef6d228c7dba8363ce147450c3c2c3ab95642d4c"
 


### PR DESCRIPTION
URLs for git on savannah.gnu.org have changed. Visible here: https://gitweb.git.savannah.gnu.org/gitweb/?p=libiconv.git