### PR TITLE
Use the official WineHQ instead of Ubuntu's Wine

### DIFF
--- a/images/base-win32/Dockerfile
+++ b/images/base-win32/Dockerfile
@@ -20,9 +20,10 @@ RUN \
     mkdir /opt/ffbuild
 
 RUN \
-    dpkg --add-architecture i386 && \
+    wget -O - https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key - && \
+    wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/questing/winehq-questing.sources && \
     apt-get -y update && \
-    apt-get -y install --no-install-recommends wine32 wine-stable && \
+    apt-get -y install --install-recommends winehq-stable && \
     apt-get -y clean autoclean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/images/base-win64/Dockerfile
+++ b/images/base-win64/Dockerfile
@@ -20,8 +20,10 @@ RUN \
     mkdir /opt/ffbuild
 
 RUN \
+    wget -O - https://dl.winehq.org/wine-builds/winehq.key | gpg --dearmor -o /etc/apt/keyrings/winehq-archive.key - && \
+    wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/ubuntu/dists/questing/winehq-questing.sources && \
     apt-get -y update && \
-    apt-get -y install --no-install-recommends wine-stable && \
+    apt-get -y install winehq-stable && \
     apt-get -y clean autoclean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I followed most of the setup instructions in the [official guide](https://gitlab.winehq.org/wine/wine/-/wikis/Debian-Ubuntu).
The Ubuntu 25.10 we're using comes with WoW64 packages, so there's no need to add the i386 architecture.