### PR TITLE
Add libunibreak for libass ASS_FEATURE_WRAP_UNICODE

### DIFF
--- a/scripts.d/45-libunibreak.sh
+++ b/scripts.d/45-libunibreak.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+SCRIPT_REPO="https://github.com/adah1972/libunibreak.git"
+SCRIPT_COMMIT="32dc4fabf20176aeaa63c4880cc53cc123e53261"
+
+ffbuild_depends() {
+    return 0
+}
+
+ffbuild_enabled() {
+    return 0
+}
+
+ffbuild_dockerbuild() {
+    ./autogen.sh
+
+    local myconf=(
+        --prefix="$FFBUILD_PREFIX"
+        --disable-shared
+        --enable-static
+        --with-pic
+    )
+
+    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+        myconf+=(
+            --host="$FFBUILD_TOOLCHAIN"
+        )
+    else
+        echo "Unknown target"
+        return -1
+    fi
+
+    ./configure "${myconf[@]}"
+    make -j$(nproc)
+    make install DESTDIR="$FFBUILD_DESTDIR"
+}


### PR DESCRIPTION
When burning ass subtitles into video,

```bash
ffmpeg -y -i input.mp4 -vf subtitles=subtitles.ass:wrap_unicode=1 -c:a copy output.mp4
```

current ffmpeg build shows

```
libass wasn't built with ASS_FEATURE_WRAP_UNICODE support
```

libass needs [libunibreak](https://github.com/adah1972/libunibreak) to support wrapping long continuous CJK chars.

https://github.com/libass/libass/blob/fadc390583f24eb5cf98f16925fd3adee50bca88/configure.ac#L36
https://github.com/libass/libass/blob/fadc390583f24eb5cf98f16925fd3adee50bca88/configure.ac#L123-L134