### PR TITLE
Enable ffnvcodec on winarm64

### DIFF
--- a/scripts.d/50-ffnvcodec.sh
+++ b/scripts.d/50-ffnvcodec.sh
@@ -16,7 +16,9 @@ SCRIPT_COMMIT4="f8339c06648fb6642aac1261d76e4158dc0b5401"
 SCRIPT_BRANCH4="sdk/12.2"
 
 ffbuild_enabled() {
-    [[ $TARGET == winarm64 ]] && return -1
+    # The upstream configure change that allows nvenc/nvdec/cuvid on aarch64
+    # Windows is not backported, so winarm64 is only supported on master (>801).
+    [[ $TARGET == winarm64 ]] && (( $(ffbuild_ffver) <= 801 )) && return -1
     (( $(ffbuild_ffver) >= 404 )) || return -1
     return 0
 }


### PR DESCRIPTION
Pairs with the upstream FFmpeg configure change that stops disabling ffnvcodec/cuvid/nvdec/nvenc on aarch64 Windows targets.