### PR TITLE
Fix LDFLAFS typo

### DIFF
--- a/scripts.d/45-x11/20-libxau.sh
+++ b/scripts.d/45-x11/20-libxau.sh
@@ -28,7 +28,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/30-libxcb.sh
+++ b/scripts.d/45-x11/30-libxcb.sh
@@ -29,7 +29,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/40-libx11.sh
+++ b/scripts.d/45-x11/40-libx11.sh
@@ -40,7 +40,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxext.sh
+++ b/scripts.d/45-x11/50-libxext.sh
@@ -38,7 +38,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS -D_GNU_SOURCE"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxfixes.sh
+++ b/scripts.d/45-x11/50-libxfixes.sh
@@ -28,7 +28,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxi.sh
+++ b/scripts.d/45-x11/50-libxi.sh
@@ -34,7 +34,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxinerama.sh
+++ b/scripts.d/45-x11/50-libxinerama.sh
@@ -34,7 +34,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxrender.sh
+++ b/scripts.d/45-x11/50-libxrender.sh
@@ -34,7 +34,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxscrnsaver.sh
+++ b/scripts.d/45-x11/50-libxscrnsaver.sh
@@ -34,7 +34,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/50-libxxf86vm.sh
+++ b/scripts.d/45-x11/50-libxxf86vm.sh
@@ -34,7 +34,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/60-libxcursor.sh
+++ b/scripts.d/45-x11/60-libxcursor.sh
@@ -28,7 +28,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/60-libxrandr.sh
+++ b/scripts.d/45-x11/60-libxrandr.sh
@@ -34,7 +34,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/45-x11/60-libxv.sh
+++ b/scripts.d/45-x11/60-libxv.sh
@@ -36,7 +36,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/scripts.d/50-vaapi/30-libpciaccess.sh
+++ b/scripts.d/50-vaapi/30-libpciaccess.sh
@@ -33,7 +33,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     meson setup "${myconf[@]}" ..
     ninja -j$(nproc)

--- a/scripts.d/50-vaapi/40-libdrm.sh
+++ b/scripts.d/50-vaapi/40-libdrm.sh
@@ -37,7 +37,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     meson "${myconf[@]}" ..
     ninja -j$(nproc)

--- a/scripts.d/50-vaapi/50-libva.sh
+++ b/scripts.d/50-vaapi/50-libva.sh
@@ -58,7 +58,7 @@ ffbuild_dockerbuild() {
     fi
 
     export CFLAGS="$RAW_CFLAGS"
-    export LDFLAFS="$RAW_LDFLAGS"
+    export LDFLAGS="$RAW_LDFLAGS"
 
     meson "${myconf[@]}" ..
     ninja -j"$(nproc)"


### PR DESCRIPTION
This pull request corrects a repeated typo in several build scripts by replacing `LDFLAFS` with the correct environment variable `LDFLAGS`. This ensures that the linker flags are properly set during the build process for various X11 and VAAPI-related libraries.

**Build script corrections:**

* Fixed typo from `LDFLAFS` to `LDFLAGS` in the following X11 build scripts to ensure linker flags are set correctly:
  * `20-libxau.sh`
  * `30-libxcb.sh`
  * `40-libx11.sh`
  * `50-libxext.sh`
  * `50-libxfixes.sh`
  * `50-libxi.sh`
  * `50-libxinerama.sh`
  * `50-libxrender.sh`
  * `50-libxscrnsaver.sh`
  * `50-libxxf86vm.sh`
  * `60-libxcursor.sh`
  * `60-libxrandr.sh`
  * `60-libxv.sh`

* Fixed the same typo in VAAPI-related build scripts:
  * `30-libpciaccess.sh`
  * `40-libdrm.sh`
  * `50-libva.sh`

These changes improve build reliability by ensuring the correct environment variable is used for linker flags throughout the scripts.