### PR TITLE
Fix default branch detection

### DIFF
--- a/util/update_scripts.sh
+++ b/util/update_scripts.sh
@@ -67,7 +67,7 @@ echo "Processing ${scr}"
             else
                 if [[ -z "${CUR_BRANCH}" ]]; then
                     # Fetch default branch name
-                    CUR_BRANCH="$(git remote show "${CUR_REPO}" | grep "HEAD branch:" | cut -d":" -f2 | xargs)"
+                    CUR_BRANCH="$(git ls-remote --symref --exit-code "${CUR_REPO}" HEAD | awk '/^ref:/ {print $2}' | sed 's|refs/heads/||')"
                     echo "Found default branch ${CUR_BRANCH}"
                 fi
                 NEW_COMMIT="$(git ls-remote --exit-code --heads --refs "${CUR_REPO}" refs/heads/"${CUR_BRANCH}" | cut -f1)"


### PR DESCRIPTION
This pull request updates the way the default branch name is detected in the `util/update_scripts.sh` script. The new approach uses a more direct and reliable `git ls-remote --symref` command instead of parsing the output of `git remote show`.

- Improved detection of the default branch name by replacing the use of `git remote show` with `git ls-remote --symref` and related parsing, making the script more robust and less dependent on output formatting.