### PR TITLE
Add git.kernel.org snapshot as a fallback for Linux sources

### DIFF
--- a/images/base-linux32/Dockerfile
+++ b/images/base-linux32/Dockerfile
@@ -4,6 +4,7 @@ FROM $GH_REPO/base:latest${BASE_TAG_SUFFIX}
 
 RUN --mount=src=ct-ng-config,dst=/.config \
     git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    rm -rf packages/linux/*/chksum && \
     ./bootstrap && \
     ./configure --enable-local && \
     make -j$(nproc) && \

--- a/images/base-linux32/ct-ng-config
+++ b/images/base-linux32/ct-ng-config
@@ -76,7 +76,7 @@ CT_DOWNLOAD_AGENT_WGET=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
 # CT_FORCE_DOWNLOAD is not set
-CT_CONNECT_TIMEOUT=10
+CT_CONNECT_TIMEOUT=60
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
@@ -333,7 +333,7 @@ CT_LINUX_V_4_18=y
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
 CT_LINUX_VERSION="4.18.20"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION}) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"

--- a/images/base-linux64/Dockerfile
+++ b/images/base-linux64/Dockerfile
@@ -4,6 +4,7 @@ FROM $GH_REPO/base:latest${BASE_TAG_SUFFIX}
 
 RUN --mount=src=ct-ng-config,dst=/.config \
     git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    rm -rf packages/linux/*/chksum && \
     ./bootstrap && \
     ./configure --enable-local && \
     make -j$(nproc) && \

--- a/images/base-linux64/ct-ng-config
+++ b/images/base-linux64/ct-ng-config
@@ -76,7 +76,7 @@ CT_DOWNLOAD_AGENT_WGET=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
 # CT_FORCE_DOWNLOAD is not set
-CT_CONNECT_TIMEOUT=10
+CT_CONNECT_TIMEOUT=60
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
@@ -333,7 +333,7 @@ CT_LINUX_V_4_18=y
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
 CT_LINUX_VERSION="4.18.20"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION}) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"

--- a/images/base-linuxarm64/Dockerfile
+++ b/images/base-linuxarm64/Dockerfile
@@ -4,6 +4,7 @@ FROM $GH_REPO/base:latest${BASE_TAG_SUFFIX}
 
 RUN --mount=src=ct-ng-config,dst=/.config \
     git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    rm -rf packages/linux/*/chksum && \
     ./bootstrap && \
     ./configure --enable-local && \
     make -j$(nproc) && \

--- a/images/base-linuxarm64/ct-ng-config
+++ b/images/base-linuxarm64/ct-ng-config
@@ -76,7 +76,7 @@ CT_DOWNLOAD_AGENT_WGET=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
 # CT_FORCE_DOWNLOAD is not set
-CT_CONNECT_TIMEOUT=10
+CT_CONNECT_TIMEOUT=60
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
@@ -339,7 +339,7 @@ CT_LINUX_V_4_18=y
 # CT_LINUX_V_3_12 is not set
 # CT_LINUX_V_3_10 is not set
 CT_LINUX_VERSION="4.18.20"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION}) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"

--- a/images/base-linuxmips64/Dockerfile
+++ b/images/base-linuxmips64/Dockerfile
@@ -4,6 +4,7 @@ FROM $GH_REPO/base:latest${BASE_TAG_SUFFIX}
 
 RUN --mount=src=ct-ng-config,dst=/.config \
     git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    rm -rf packages/linux/*/chksum && \
     ./bootstrap && \
     ./configure --enable-local && \
     make -j$(nproc) && \

--- a/images/base-linuxmips64/ct-ng-config
+++ b/images/base-linuxmips64/ct-ng-config
@@ -77,7 +77,7 @@ CT_DOWNLOAD_AGENT_WGET=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
 # CT_FORCE_DOWNLOAD is not set
-CT_CONNECT_TIMEOUT=10
+CT_CONNECT_TIMEOUT=60
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
@@ -343,7 +343,7 @@ CT_LINUX_V_6_1=y
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
 CT_LINUX_VERSION="6.1.159"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION}) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"

--- a/images/base-linuxppc64/Dockerfile
+++ b/images/base-linuxppc64/Dockerfile
@@ -4,6 +4,7 @@ FROM $GH_REPO/base:latest${BASE_TAG_SUFFIX}
 
 RUN --mount=src=ct-ng-config,dst=/.config \
     git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    rm -rf packages/linux/*/chksum && \
     ./bootstrap && \
     ./configure --enable-local && \
     make -j$(nproc) && \

--- a/images/base-linuxppc64/ct-ng-config
+++ b/images/base-linuxppc64/ct-ng-config
@@ -77,7 +77,7 @@ CT_DOWNLOAD_AGENT_WGET=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
 # CT_FORCE_DOWNLOAD is not set
-CT_CONNECT_TIMEOUT=10
+CT_CONNECT_TIMEOUT=60
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
@@ -346,7 +346,7 @@ CT_LINUX_V_6_1=y
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
 CT_LINUX_VERSION="6.1.159"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION}) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"

--- a/images/base-linuxriscv64/Dockerfile
+++ b/images/base-linuxriscv64/Dockerfile
@@ -4,6 +4,7 @@ FROM $GH_REPO/base:latest${BASE_TAG_SUFFIX}
 
 RUN --mount=src=ct-ng-config,dst=/.config \
     git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    rm -rf packages/linux/*/chksum && \
     ./bootstrap && \
     ./configure --enable-local && \
     make -j$(nproc) && \

--- a/images/base-linuxriscv64/ct-ng-config
+++ b/images/base-linuxriscv64/ct-ng-config
@@ -77,7 +77,7 @@ CT_DOWNLOAD_AGENT_WGET=y
 # CT_DOWNLOAD_AGENT_NONE is not set
 # CT_FORBID_DOWNLOAD is not set
 # CT_FORCE_DOWNLOAD is not set
-CT_CONNECT_TIMEOUT=10
+CT_CONNECT_TIMEOUT=60
 CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
 # CT_ONLY_DOWNLOAD is not set
 # CT_USE_MIRROR is not set
@@ -333,7 +333,7 @@ CT_LINUX_V_6_1=y
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
 CT_LINUX_VERSION="6.1.159"
-CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION}) https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/snapshot"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"


### PR DESCRIPTION
Snapshots have different checksums, thereby bypassing the checksum check performed by ct-ng.

Additionally, the wget timeout in ct-ng has been increased.
Creating the snapshot takes time, usually around 30s if it's the first request in the recent period. It's set to 60s here to account for potential network fluctuations.

Once cdn.kernel.org comes back, it will still be prioritized.

- https://status.linuxfoundation.org/incidents/3y1k8b4ky71t
- https://github.com/BtbN/FFmpeg-Builds/issues/634