### PR TITLE
Fix $ORIGIN rpath on shared builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,11 +27,22 @@ GIT_BRANCH="${GIT_BRANCH_OVERRIDE:-$GIT_BRANCH}"
 BUILD_SCRIPT="$(mktemp)"
 trap "rm -f -- '$BUILD_SCRIPT'" EXIT
 
-cat <<EOF >"$BUILD_SCRIPT"
+# Expand the @ORIGIN@ placeholder emitted by scripts.d/99-rpath.sh. Quoted
+# heredoc: nothing below is expanded on the host, it runs in the container.
+# \\\$\$ORIGIN is what configure must receive, because from there:
+#   configure's append() eval  \\\$\$ORIGIN -> \$$ORIGIN  (into config.mak)
+#   make expanding config.mak  \$$ORIGIN    -> \$ORIGIN
+#   the shell running the link \$ORIGIN     -> $ORIGIN
+cat <<'EOF' >"$BUILD_SCRIPT"
     set -xe
     cd /ffbuild
     rm -rf ffmpeg prefix
 
+    RPATH_ORIGIN='\\\$\$ORIGIN'
+    FF_LDEXEFLAGS="${FF_LDEXEFLAGS//@ORIGIN@/$RPATH_ORIGIN}"
+EOF
+
+cat <<EOF >>"$BUILD_SCRIPT"
     git clone --filter=blob:none --branch='$GIT_BRANCH' '$FFMPEG_REPO' ffmpeg
     cd ffmpeg
 
@@ -43,6 +54,19 @@ cat <<EOF >"$BUILD_SCRIPT"
     make -j\$(nproc) V=1
     make install install-doc
 EOF
+
+# A broken $ORIGIN rpath still builds and still runs anywhere ld.so.cache
+# happens to know the libs, so it fails silently. Assert it instead.
+if [[ $TARGET == linux* && $VARIANT == *shared* ]]; then
+cat <<'EOF' >>"$BUILD_SCRIPT"
+    readelf -d /ffbuild/prefix/bin/ffmpeg | grep -q ORIGIN || {
+        echo "ERROR: ffmpeg was linked without an \$ORIGIN rpath." >&2
+        echo "       See the @ORIGIN@ handling in build.sh / scripts.d/99-rpath.sh." >&2
+        readelf -d /ffbuild/prefix/bin/ffmpeg | grep -i rpath >&2
+        exit 1
+    }
+EOF
+fi
 
 [[ -t 1 ]] && TTY_ARG="-t" || TTY_ARG=""
 

--- a/scripts.d/99-rpath.sh
+++ b/scripts.d/99-rpath.sh
@@ -30,8 +30,19 @@ ffbuild_ldexeflags() {
     echo '-pie'
 
     if [[ $VARIANT == *shared* ]]; then
-        # Can't escape escape hell
-        echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN'
-        echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN/../lib'
+        # Emit a placeholder rather than a pre-escaped $ORIGIN.
+        #
+        # A literal $ORIGIN written here has to survive, in order: xargs and
+        # printf in generate.sh, Dockerfile ENV parsing, ffmpeg configure's
+        # append() eval, make expanding config.mak, and finally the shell that
+        # runs the link. Each strips escapes, and the count is not stable --
+        # the xargs added in 281ab29 (2024-03-14) silently ate one level and
+        # every linux shared build since has shipped RPATH "-Wl:../lib"
+        # instead of "$ORIGIN:$ORIGIN/../lib".
+        #
+        # build.sh substitutes @ORIGIN@ inside the container instead, one
+        # shell layer away from configure, where the escaping is knowable.
+        echo -Wl,-rpath=@ORIGIN@
+        echo -Wl,-rpath=@ORIGIN@/../lib
     fi
 }


### PR DESCRIPTION
Fixes #560.

`scripts.d/99-rpath.sh` has emitted `$ORIGIN` rpath flags for linux shared builds since [a0384b8](https://github.com/BtbN/FFmpeg-Builds/commit/a0384b8) (2021), but the escaped literal stopped surviving the pipeline in 2024, and every linux shared release since has shipped a mangled rpath:

```
$ readelf -d ffmpeg-master-latest-linux64-gpl-shared/bin/ffmpeg | grep RPATH
0x000000000000000f (RPATH)   Library rpath: [-Wl:../lib]
```

Confirmed against released tarballs: `autobuild-2026-02-28` (N-123074), `autobuild-2026-06-30` (N-125365) and `autobuild-2026-08-03` (N-125953) all carry `[-Wl:../lib]`.

## Root cause

[281ab29](https://github.com/BtbN/FFmpeg-Builds/commit/281ab29) (2024-03-14) added the `xargs` normalisation at `generate.sh:230`, which unescapes one level, the level `99-rpath.sh`'s literal depended on:

```
configure sees \$$ORIGIN     (with xargs)     ->  RPATH: $
configure sees \\\$\$ORIGIN  (without xargs)  ->  RPATH: $ORIGIN
```

What reaches the linker with the current escaping:

1. `configure`'s `append()` runs `eval "$var=\"\$$var $*\""`; inside those quotes `\$` -> `$` and the unset `$ORIGIN` expands to nothing, so `config.mak` gets `-Wl,-rpath=$ -Wl,-rpath=$/../lib`.
2. `make` treats `$ ` and `$/` as single-character variable references, both empty, **merging the two flags into one token**: `-Wl,-rpath=-Wl,-rpath=../lib`.
3. gcc splits that on commas, `ld` receives `-rpath=-Wl` and `-rpath=../lib`, giving `RPATH [-Wl:../lib]`.

## fix

- `99-rpath.sh` emits a plain `@ORIGIN@` placeholder. It contains no shell or printf metacharacters, so `xargs`, `printf` and Dockerfile `ENV` parsing pass it through untouched.
- `build.sh` substitutes it inside the container, from a quoted heredoc (nothing expanded host-side), one shell layer from `configure`  where the required value is knowable and can be documented:
  ```sh
  RPATH_ORIGIN='\\\$\$ORIGIN'
  FF_LDEXEFLAGS="${FF_LDEXEFLAGS//@ORIGIN@/$RPATH_ORIGIN}"
  ```
- `build.sh` also gains a post-build assertion for linux shared variants. A broken `$ORIGIN` rpath still builds and still runs anywhere `ld.so.cache` knows the libraries, which is why this went unnoticed for two years  so it now fails the build instead:
  ```sh
  readelf -d /ffbuild/prefix/bin/ffmpeg | grep -q ORIGIN || { ...; exit 1; }
  ```

The substitution is a no-op for non-shared and non-linux variants, and the assertion is only emitted for `linux* + *shared*`, so other targets are untouched.

## Verification

Traced end to end through the chain, `generate.sh` output -> Docker `ENV` parsing -> `configure`'s `append()`/`eval` -> `config.mak` -> `make` -> `sh` -> `gcc`:

```
Dockerfile ENV : FF_LDEXEFLAGS="-pie -Wl,-rpath=@ORIGIN@ -Wl,-rpath=@ORIGIN@/../lib"
configure gets : -pie -Wl,-rpath=\\\$\$ORIGIN -Wl,-rpath=\\\$\$ORIGIN/../lib
config.mak     : LDEXEFLAGS= -pie -Wl,-rpath=\$$ORIGIN -Wl,-rpath=\$$ORIGIN/../lib
RESULTING RPATH: $ORIGIN:$ORIGIN/../lib
```
