### PR TITLE
Fix $ORIGIN rpath on shared builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,11 +27,34 @@ GIT_BRANCH="${GIT_BRANCH_OVERRIDE:-$GIT_BRANCH}"
 BUILD_SCRIPT="$(mktemp)"
 trap "rm -f -- '$BUILD_SCRIPT'" EXIT
 
-cat <<EOF >"$BUILD_SCRIPT"
+cat <<'EOF' >"$BUILD_SCRIPT"
     set -xe
     cd /ffbuild
     rm -rf ffmpeg prefix
+EOF
 
+# Append the $ORIGIN rpath flags here rather than in scripts.d/99-rpath.sh, so
+# the value never has to survive xargs, printf and Dockerfile ENV parsing.
+#
+# Both quotings below are needed:
+#   - the heredoc delimiter is quoted, so the host expands nothing
+#   - the appended fragment is single-quoted and *concatenated*, so the
+#     container's shell performs no substitution on it either
+# Do not switch this to "${FF_LDEXEFLAGS//@PLACEHOLDER@/$var}" -- bash's pattern
+# substitution eats a backslash from the replacement on some bash versions but
+# not others, which silently costs one escaping level.
+#
+# configure must receive exactly  -Wl,-rpath=\\\$\$ORIGIN  because from there:
+#   configure's append() eval  \\\$\$ORIGIN -> \$$ORIGIN  (into config.mak)
+#   make expanding config.mak  \$$ORIGIN    -> \$ORIGIN
+#   the shell running the link \$ORIGIN     -> $ORIGIN
+if [[ $TARGET == linux* && $VARIANT == *shared* ]]; then
+cat <<'EOF' >>"$BUILD_SCRIPT"
+    FF_LDEXEFLAGS="$FF_LDEXEFLAGS "'-Wl,-rpath=\\\$\$ORIGIN -Wl,-rpath=\\\$\$ORIGIN/../lib'
+EOF
+fi
+
+cat <<EOF >>"$BUILD_SCRIPT"
     git clone --filter=blob:none --branch='$GIT_BRANCH' '$FFMPEG_REPO' ffmpeg
     cd ffmpeg
 
@@ -43,6 +66,19 @@ cat <<EOF >"$BUILD_SCRIPT"
     make -j\$(nproc) V=1
     make install install-doc
 EOF
+
+# A broken $ORIGIN rpath still builds and still runs anywhere ld.so.cache
+# happens to know the libs, so it fails silently - so check and assert.
+if [[ $TARGET == linux* && $VARIANT == *shared* ]]; then
+cat <<'EOF' >>"$BUILD_SCRIPT"
+    readelf -d /ffbuild/prefix/bin/ffmpeg | grep -q ORIGIN || {
+        echo "ERROR: ffmpeg was linked without an \$ORIGIN rpath." >&2
+        echo "       See the FF_LDEXEFLAGS rpath append earlier in build.sh." >&2
+        readelf -d /ffbuild/prefix/bin/ffmpeg | grep -i rpath >&2
+        exit 1
+    }
+EOF
+fi
 
 [[ -t 1 ]] && TTY_ARG="-t" || TTY_ARG=""
 

--- a/scripts.d/99-rpath.sh
+++ b/scripts.d/99-rpath.sh
@@ -29,9 +29,14 @@ ffbuild_dockerbuild() {
 ffbuild_ldexeflags() {
     echo '-pie'
 
-    if [[ $VARIANT == *shared* ]]; then
-        # Can't escape escape hell
-        echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN'
-        echo -Wl,-rpath='\\\\\\\$\\\$ORIGIN/../lib'
-    fi
+    # The $ORIGIN rpath flags for shared linux builds are deliberately NOT
+    # emitted here -- build.sh appends them inside the container instead.
+    #
+    # A literal $ORIGIN written here would have to survive, in order: xargs and
+    # printf in generate.sh, Dockerfile ENV parsing, ffmpeg configure's append()
+    # eval, make expanding config.mak, and finally the shell that runs the link.
+    # Each strips escapes and the required count is not stable: the xargs added
+    # in 281ab29 (2024-03-14) silently ate one level, and every linux shared
+    # build since has shipped RPATH "-Wl:../lib" instead of
+    # "$ORIGIN:$ORIGIN/../lib".
 }


### PR DESCRIPTION
Fixes #560.

`scripts.d/99-rpath.sh` has emitted `$ORIGIN` rpath flags for linux shared builds since [a0384b8](https://github.com/BtbN/FFmpeg-Builds/commit/a0384b8) (2021), but the escaped literal stopped surviving the pipeline in 2024, and every linux shared release since has shipped a mangled rpath:

```
$ readelf -d ffmpeg-master-latest-linux64-gpl-shared/bin/ffmpeg | grep RPATH
0x000000000000000f (RPATH)   Library rpath: [-Wl:../lib]
```

Confirmed against released tarballs. `autobuild-2026-02-28` (N-123074), `autobuild-2026-06-30` (N-125365) and `autobuild-2026-08-03` (N-125953) all carry `[-Wl:../lib]`.

## Root cause

[281ab29](https://github.com/BtbN/FFmpeg-Builds/commit/281ab29) (2024-03-14) added the `xargs` normalisation at `generate.sh:230`, which unescapes one level. That is the level `99-rpath.sh`'s literal depended on:

```
configure sees \$$ORIGIN     (with xargs)     ->  RPATH: $
configure sees \\\$\$ORIGIN  (without xargs)  ->  RPATH: $ORIGIN
```

What reaches the linker with the current escaping:

1. `configure`'s `append()` runs `eval "$var=\"\$$var $*\""`. Inside those quotes `\$` becomes `$`, and the unset `$ORIGIN` expands to nothing, so `config.mak` gets `-Wl,-rpath=$ -Wl,-rpath=$/../lib`.
2. `make` treats `$ ` and `$/` as single-character variable references, both empty, merging the two flags into one token: `-Wl,-rpath=-Wl,-rpath=../lib`.
3. gcc splits that on commas, `ld` receives `-rpath=-Wl` and `-rpath=../lib`, giving `RPATH [-Wl:../lib]`.

Step 2 explains both the merge and the missing leading slash.

## Fix

Not by adding more backslashes. That is what caused the bug, and it cannot be made reliable: the chain has five unescaping layers, and one of them is `to_df()`'s `printf "$@"` (seperate issue in itself), which uses caller data as a format string. 

Instead the value never enters the generate/Dockerfile pipeline at all:

* `99-rpath.sh` no longer emits the rpath flags (it keeps `-pie`), so there is nothing for `xargs`, `printf` or `ENV` parsing to mangle.
* `build.sh` appends them inside the container, one shell layer from `configure`, where the required value is knowable and can be commented. The heredoc delimiter is quoted so the host expands nothing, and the fragment is single-quoted and concatenated so the container's shell substitutes nothing either:

  ```sh
  FF_LDEXEFLAGS="$FF_LDEXEFLAGS "'-Wl,-rpath=\\\$\$ORIGIN -Wl,-rpath=\\\$\$ORIGIN/../lib'
  ```

  Not `${FF_LDEXEFLAGS//@PLACEHOLDER@/$var}`. Bash's pattern substitution consumes a backslash from the replacement on some bash versions but not others, which silently costs one escaping level.

* `build.sh` also gains a post-build check for linux shared variants. A broken `$ORIGIN` rpath still builds, and still runs anywhere `ld.so.cache` knows the libraries, which is why this went unnoticed for two years. It now fails the build instead:

  ```sh
  readelf -d /ffbuild/prefix/bin/ffmpeg | grep -q ORIGIN || { ...; exit 1; }
  ```

Both additions are gated on `linux* + *shared*`, so win and static targets generate the same build script as before.

## Verification

Traced end to end through the real chain: `generate.sh` output, Docker `ENV` parsing, `configure`'s `append()`/`eval`, `config.mak`, `make`, `sh`, `gcc`.

```
Dockerfile ENV : FF_LDEXEFLAGS="-pie"
configure gets : -pie -Wl,-rpath=\\\$\$ORIGIN -Wl,-rpath=\\\$\$ORIGIN/../lib
config.mak     : LDEXEFLAGS= -pie -Wl,-rpath=\$$ORIGIN -Wl,-rpath=\$$ORIGIN/../lib
make emits     : gcc ... -pie -Wl,-rpath=\$ORIGIN -Wl,-rpath=\$ORIGIN/../lib
RESULTING RPATH: $ORIGIN:$ORIGIN/../lib
```

confirmed on real `linux64 gpl-shared` builds, twice: once against the prebuilt variant image, and once rebuilding the variant image from `base-linux64` the way CI does.

```
+ FF_LDEXEFLAGS='-pie -Wl,-rpath=\\\$\$ORIGIN -Wl,-rpath=\\\$\$ORIGIN/../lib'
...
0x000000000000000f (RPATH)   Library rpath: [$ORIGIN:$ORIGIN/../lib]
```

Unpacked elsewhere and run from an unrelated working directory:

```
$ cd /tmp && ldd .../check/bin/ffmpeg
libavdevice.so.63 => .../check/bin/../lib/libavdevice.so.63
```

so the binary is self-locating, which is what #560 asked for.
